### PR TITLE
Add new int_timestamp property in preparation for 1.0.0 release

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -694,7 +694,8 @@ class Arrow(object):
 
         warnings.warn(
             "For compatibility with the datetime.timestamp() method this property will be replaced with a method in "
-            "the 1.0.0 release, please switch to .int_timestamp for identical behaviour as soon as possible.",
+            "the 1.0.0 release, please switch to the .int_timestamp property for identical behaviour as soon as "
+            "possible.",
             DeprecationWarning,
         )
         return calendar.timegm(self._datetime.utctimetuple())

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -693,14 +693,23 @@ class Arrow(object):
         """
 
         warnings.warn(
-            "For datetime compatibility reasons this property will be removed in the future, instead use "
-            ".unix_timestamp for the same behaviour",
-            PendingDeprecationWarning,
+            "For compatibility with the datetime.timestamp() method this property will removed in the 1.0.0 release, "
+            "please switch to .int_timestamp for identical behaviour as soon as possible.",
+            DeprecationWarning,
         )
         return calendar.timegm(self._datetime.utctimetuple())
 
     @property
-    def unix_timestamp(self):
+    def int_timestamp(self):
+        """Returns a timestamp representation of the :class:`Arrow <arrow.arrow.Arrow>` object, in
+        UTC time.
+
+        Usage::
+
+            >>> arrow.utcnow().timestamp
+            1548260567
+
+        """
 
         return calendar.timegm(self._datetime.utctimetuple())
 
@@ -716,10 +725,11 @@ class Arrow(object):
 
         """
 
-        # IDEA get rid of this in 1.0.0 and make a timestamp method?
+        # IDEA get rid of this in 1.0.0 and wrap datetime.timestamp()
         # Or for compatibility retain this but make it call the timestamp method
-        # return self.timestamp + float(self.microsecond) / 1000000
-        return self._datetime.timestamp()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            return self.timestamp + float(self.microsecond) / 1000000
 
     @property
     def fold(self):

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -693,7 +693,8 @@ class Arrow(object):
         """
 
         warnings.warn(
-            "For datetime compatibility reasons this property will be removed in the future, instead use .unix_timestamp",
+            "For datetime compatibility reasons this property will be removed in the future, instead use "
+            ".unix_timestamp for the same behaviour",
             PendingDeprecationWarning,
         )
         return calendar.timegm(self._datetime.utctimetuple())
@@ -715,6 +716,8 @@ class Arrow(object):
 
         """
 
+        # IDEA get rid of this in 1.0.0 and make a timestamp method?
+        # Or for compatibility retain this but make it call the timestamp method
         # return self.timestamp + float(self.microsecond) / 1000000
         return self._datetime.timestamp()
 

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -693,8 +693,8 @@ class Arrow(object):
         """
 
         warnings.warn(
-            "For compatibility with the datetime.timestamp() method this property will removed in the 1.0.0 release, "
-            "please switch to .int_timestamp for identical behaviour as soon as possible.",
+            "For compatibility with the datetime.timestamp() method this property will be replaced with a method in "
+            "the 1.0.0 release, please switch to .int_timestamp for identical behaviour as soon as possible.",
             DeprecationWarning,
         )
         return calendar.timegm(self._datetime.utctimetuple())
@@ -706,7 +706,7 @@ class Arrow(object):
 
         Usage::
 
-            >>> arrow.utcnow().timestamp
+            >>> arrow.utcnow().int_timestamp
             1548260567
 
         """

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -692,6 +692,15 @@ class Arrow(object):
 
         """
 
+        warnings.warn(
+            "For datetime compatibility reasons this property will be removed in the future, instead use .unix_timestamp",
+            PendingDeprecationWarning,
+        )
+        return calendar.timegm(self._datetime.utctimetuple())
+
+    @property
+    def unix_timestamp(self):
+
         return calendar.timegm(self._datetime.utctimetuple())
 
     @property
@@ -706,7 +715,8 @@ class Arrow(object):
 
         """
 
-        return self.timestamp + float(self.microsecond) / 1000000
+        # return self.timestamp + float(self.microsecond) / 1000000
+        return self._datetime.timestamp()
 
     @property
     def fold(self):

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -283,12 +283,12 @@ class TestArrowAttribute:
             self.arrow._datetime.utctimetuple()
         )
 
-        with pytest.warns(PendingDeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             self.arrow.timestamp
 
-    def test_unix_timestamp(self):
+    def test_int_timestamp(self):
 
-        assert self.arrow.unix_timestamp == calendar.timegm(
+        assert self.arrow.int_timestamp == calendar.timegm(
             self.arrow._datetime.utctimetuple()
         )
 

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -283,6 +283,15 @@ class TestArrowAttribute:
             self.arrow._datetime.utctimetuple()
         )
 
+        with pytest.warns(PendingDeprecationWarning):
+            self.arrow.timestamp
+
+    def test_unix_timestamp(self):
+
+        assert self.arrow.unix_timestamp == calendar.timegm(
+            self.arrow._datetime.utctimetuple()
+        )
+
     def test_float_timestamp(self):
 
         result = self.arrow.float_timestamp - self.arrow.timestamp


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets: [x] -->
- [ ] 🧪 Added **tests** for changed code.
- [ ] 🛠️ All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [ ] 🧹 All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚 Updated **documentation** for changed code.
- [ ] ⏩ Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

This is the start of implementing #465 

- New property `int_timestamp` that does exactly the same thing as `.timestamp`.
- `timestamp` will be removed in 1.0.0
- I have not touched `float_timestamp` in this PR.
- `float_timestamp` essentially does the same as `datetime.timestamp()`, we could leave it as a legacy property.