### PR TITLE
Fix range behaviour at end of month/quarter/year frames (#842)

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -387,7 +387,7 @@ class Arrow(object):
                 **{frame_relative: relative_steps}
             )
 
-            if frame == "month" and current.day < original_day:
+            if frame in ["month", "quarter"] and current.day < original_day:
                 day_is_clipped = True
 
             if day_is_clipped and not cls._is_last_day_of_month(current):

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -1542,8 +1542,8 @@ class Arrow(object):
                 return end, sys.maxsize
             return end, limit
 
-    @classmethod
-    def _is_last_day_of_month(cls, date):
+    @staticmethod
+    def _is_last_day_of_month(date):
         return (date + timedelta(days=1)).day == 1
 
 

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -387,7 +387,7 @@ class Arrow(object):
                 **{frame_relative: relative_steps}
             )
 
-            if frame in ["month", "quarter"] and current.day < original_day:
+            if frame in ["month", "quarter", "year"] and current.day < original_day:
                 day_is_clipped = True
 
             if day_is_clipped and not cls._is_last_day_of_month(current):

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -1544,7 +1544,7 @@ class Arrow(object):
 
     @staticmethod
     def _is_last_day_of_month(date):
-        return (date + timedelta(days=1)).day == 1
+        return date.day == calendar.monthrange(date.year, date.month)[1]
 
 
 Arrow.min = Arrow.fromdatetime(datetime.min)

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -374,6 +374,8 @@ class Arrow(object):
         end = cls._get_datetime(end).replace(tzinfo=tzinfo)
 
         current = cls.fromdatetime(start)
+        original_day = start.day
+        day_is_clipped = False
         i = 0
 
         while current <= end and i < limit:
@@ -384,6 +386,12 @@ class Arrow(object):
             current = cls(*values, tzinfo=tzinfo) + relativedelta(
                 **{frame_relative: relative_steps}
             )
+
+            if frame == "month" and current.day < original_day:
+                day_is_clipped = True
+
+            if day_is_clipped and not cls._is_last_day_of_month(current):
+                current = current.replace(day=original_day)
 
     def span(self, frame, count=1, bounds="[)"):
         """ Returns two new :class:`Arrow <arrow.arrow.Arrow>` objects, representing the timespan
@@ -1533,6 +1541,10 @@ class Arrow(object):
             if limit is None:
                 return end, sys.maxsize
             return end, limit
+
+    @classmethod
+    def _is_last_day_of_month(cls, date):
+        return (date + timedelta(days=1)).day == 1
 
 
 Arrow.min = Arrow.fromdatetime(datetime.min)

--- a/arrow/util.py
+++ b/arrow/util.py
@@ -90,6 +90,13 @@ def iso_to_gregorian(iso_year, iso_week, iso_day):
     return gregorian
 
 
+def validate_bounds(bounds):
+    if bounds != "()" and bounds != "(]" and bounds != "[)" and bounds != "[]":
+        raise ValueError(
+            'Invalid bounds. Please select between "()", "(]", "[)", or "[]".'
+        )
+
+
 # Python 2.7 / 3.0+ definitions for isstr function.
 
 try:  # pragma: no cover

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -1062,6 +1062,14 @@ class TestArrowRange:
             arrow.Arrow(2015, 5, 31),
         ]
 
+    def test_range_over_quarter_months_ending_on_different_days(self):
+        result = list(arrow.Arrow.range("quarter", datetime(2014, 11, 30), limit=3))
+        assert result == [
+            arrow.Arrow(2014, 11, 30),
+            arrow.Arrow(2015, 2, 28),
+            arrow.Arrow(2015, 5, 30),
+        ]
+
 
 class TestArrowSpanRange:
     def test_year(self):

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -1034,11 +1034,12 @@ class TestArrowRange:
 
     def test_range_over_months_ending_on_different_days(self):
         # regression test for issue #842
-        result = list(arrow.Arrow.range("month", datetime(2015, 1, 31), limit=3))
+        result = list(arrow.Arrow.range("month", datetime(2015, 1, 31), limit=4))
         assert result == [
             arrow.Arrow(2015, 1, 31),
             arrow.Arrow(2015, 2, 28),
             arrow.Arrow(2015, 3, 31),
+            arrow.Arrow(2015, 4, 30),
         ]
 
         result = list(arrow.Arrow.range("month", datetime(2015, 1, 30), limit=3))
@@ -1068,6 +1069,16 @@ class TestArrowRange:
             arrow.Arrow(2014, 11, 30),
             arrow.Arrow(2015, 2, 28),
             arrow.Arrow(2015, 5, 30),
+        ]
+
+    def test_range_over_year_maintains_end_date_across_leap_year(self):
+        result = list(arrow.Arrow.range("year", datetime(2012, 2, 29), limit=5))
+        assert result == [
+            arrow.Arrow(2012, 2, 29),
+            arrow.Arrow(2013, 2, 28),
+            arrow.Arrow(2014, 2, 28),
+            arrow.Arrow(2015, 2, 28),
+            arrow.Arrow(2016, 2, 29),
         ]
 
 

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -1406,7 +1406,7 @@ class TestArrowSpan:
 
     def test_bounds_are_validated(self):
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(ValueError):
             floor, ceil = self.arrow.span("hour", bounds="][")
 
 
@@ -1867,19 +1867,19 @@ class TestArrowIsBetween:
         with pytest.raises(TypeError):
             target.is_between(None, None)
 
-    def test_attribute_error_exception(self):
+    def test_value_error_exception(self):
         target = arrow.Arrow.fromdatetime(datetime(2013, 5, 7))
         start = arrow.Arrow.fromdatetime(datetime(2013, 5, 5))
         end = arrow.Arrow.fromdatetime(datetime(2013, 5, 8))
-        with pytest.raises(AttributeError):
+        with pytest.raises(ValueError):
             target.is_between(start, end, "][")
-        with pytest.raises(AttributeError):
+        with pytest.raises(ValueError):
             target.is_between(start, end, "")
-        with pytest.raises(AttributeError):
+        with pytest.raises(ValueError):
             target.is_between(start, end, "]")
-        with pytest.raises(AttributeError):
+        with pytest.raises(ValueError):
             target.is_between(start, end, "[")
-        with pytest.raises(AttributeError):
+        with pytest.raises(ValueError):
             target.is_between(start, end, "hello")
 
 

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -1032,6 +1032,36 @@ class TestArrowRange:
         with pytest.raises(AttributeError):
             next(arrow.Arrow.range("abc", datetime.utcnow(), datetime.utcnow()))
 
+    def test_range_over_months_ending_on_different_days(self):
+        # regression test for issue #842
+        result = list(arrow.Arrow.range("month", datetime(2015, 1, 31), limit=3))
+        assert result == [
+            arrow.Arrow(2015, 1, 31),
+            arrow.Arrow(2015, 2, 28),
+            arrow.Arrow(2015, 3, 31),
+        ]
+
+        result = list(arrow.Arrow.range("month", datetime(2015, 1, 30), limit=3))
+        assert result == [
+            arrow.Arrow(2015, 1, 30),
+            arrow.Arrow(2015, 2, 28),
+            arrow.Arrow(2015, 3, 30),
+        ]
+
+        result = list(arrow.Arrow.range("month", datetime(2015, 2, 28), limit=3))
+        assert result == [
+            arrow.Arrow(2015, 2, 28),
+            arrow.Arrow(2015, 3, 28),
+            arrow.Arrow(2015, 4, 28),
+        ]
+
+        result = list(arrow.Arrow.range("month", datetime(2015, 3, 31), limit=3))
+        assert result == [
+            arrow.Arrow(2015, 3, 31),
+            arrow.Arrow(2015, 4, 30),
+            arrow.Arrow(2015, 5, 31),
+        ]
+
 
 class TestArrowSpanRange:
     def test_year(self):


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets: [x] -->
- [x] 🧪 Added **tests** for changed code.
- [x] 🛠️ All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹 All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚 Updated **documentation** for changed code.
- [x] ⏩ Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

Thanks for the library. This PR provides a fix for #842 
