### PR TITLE
Improve handling of imaginary datetimes

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -381,7 +381,10 @@ class Arrow(object):
             yield current
 
             values = [getattr(current, f) for f in cls._ATTRS]
-            current = cls(*values, tzinfo=tzinfo) + relativedelta(
+            # current = cls(*values, tzinfo=tzinfo) + relativedelta(
+            #     **{frame_relative: relative_steps}
+            # )
+            current = cls(*values, tzinfo=tzinfo).shift(
                 **{frame_relative: relative_steps}
             )
 
@@ -722,7 +725,21 @@ class Arrow(object):
 
         return dateutil_tz.datetime_ambiguous(self._datetime)
 
-    # mutation and duplication
+    @property
+    def imaginary(self):
+        """Returns a boolean indicating whether the :class: `Arrow <arrow.arrow.Arrow>` object exists in the current
+        timezone """
+
+        return not dateutil_tz.datetime_exists(self._datetime)
+
+    @property
+    def imaginary(self):
+        """Returns a boolean indicating whether the :class: `Arrow <arrow.arrow.Arrow>` object exists in the current
+        timezone """
+
+        return not dateutil_tz.datetime_exists(self._datetime)
+
+    # mutation and duplication.
 
     def clone(self):
         """ Returns a new :class:`Arrow <arrow.arrow.Arrow>` object, cloned from the current one.
@@ -835,6 +852,9 @@ class Arrow(object):
         )
 
         current = self._datetime + relativedelta(**relative_kwargs)
+
+        if not dateutil_tz.datetime_exists(current):
+            current = dateutil_tz.resolve_imaginary(current)
 
         return self.fromdatetime(current)
 

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -381,9 +381,6 @@ class Arrow(object):
             yield current
 
             values = [getattr(current, f) for f in cls._ATTRS]
-            # current = cls(*values, tzinfo=tzinfo) + relativedelta(
-            #     **{frame_relative: relative_steps}
-            # )
             current = cls(*values, tzinfo=tzinfo).shift(
                 **{frame_relative: relative_steps}
             )
@@ -724,13 +721,6 @@ class Arrow(object):
         """ Returns a boolean indicating whether the :class:`Arrow <arrow.arrow.Arrow>` object is ambiguous"""
 
         return dateutil_tz.datetime_ambiguous(self._datetime)
-
-    @property
-    def imaginary(self):
-        """Returns a boolean indicating whether the :class: `Arrow <arrow.arrow.Arrow>` object exists in the current
-        timezone """
-
-        return not dateutil_tz.datetime_exists(self._datetime)
 
     @property
     def imaginary(self):

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -725,7 +725,7 @@ class Arrow(object):
     @property
     def imaginary(self):
         """Returns a boolean indicating whether the :class: `Arrow <arrow.arrow.Arrow>` object exists in the current
-        timezone """
+        timezone"""
 
         return not dateutil_tz.datetime_exists(self._datetime)
 

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -439,17 +439,17 @@ class Arrow(object):
         floor = self.__class__(*values, tzinfo=self.tzinfo)
 
         if frame_absolute == "week":
-            floor = floor + relativedelta(days=-(self.isoweekday() - 1))
+            floor = floor.shift(days=-(self.isoweekday() - 1))
         elif frame_absolute == "quarter":
-            floor = floor + relativedelta(months=-((self.month - 1) % 3))
+            floor = floor.shift(months=-((self.month - 1) % 3))
 
-        ceil = floor + relativedelta(**{frame_relative: count * relative_steps})
+        ceil = floor.shift(**{frame_relative: count * relative_steps})
 
         if bounds[0] == "(":
-            floor += relativedelta(microseconds=1)
+            floor = floor.shift(microseconds=+1)
 
         if bounds[1] == ")":
-            ceil += relativedelta(microseconds=-1)
+            ceil = ceil.shift(microseconds=-1)
 
         return floor, ceil
 

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -718,14 +718,13 @@ class Arrow(object):
 
     @property
     def ambiguous(self):
-        """ Returns a boolean indicating whether the :class:`Arrow <arrow.arrow.Arrow>` object is ambiguous"""
+        """ Returns a boolean indicating whether the :class:`Arrow <arrow.arrow.Arrow>` object is ambiguous."""
 
         return dateutil_tz.datetime_ambiguous(self._datetime)
 
     @property
     def imaginary(self):
-        """Returns a boolean indicating whether the :class: `Arrow <arrow.arrow.Arrow>` object exists in the current
-        timezone"""
+        """Indicates whether the :class: `Arrow <arrow.arrow.Arrow>` object exists in the current timezone."""
 
         return not dateutil_tz.datetime_exists(self._datetime)
 

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -7,6 +7,7 @@ import sys
 import time
 from datetime import date, datetime, timedelta
 
+import dateutil
 import pytest
 import pytz
 import simplejson as json
@@ -309,6 +310,14 @@ class TestArrowAttribute:
         ambiguous_dt = arrow.Arrow(2017, 10, 29, 2, 0, tzinfo="Europe/Stockholm")
 
         assert ambiguous_dt.ambiguous
+
+    def test_getattr_imaginary(self):
+
+        assert not self.now.imaginary
+
+        imaginary_dt = arrow.Arrow(2013, 3, 31, 2, 30, tzinfo="Europe/Paris")
+
+        assert imaginary_dt.imaginary
 
 
 @pytest.mark.usefixtures("time_utcnow")
@@ -838,6 +847,85 @@ class TestArrowShift:
             2013, 5, 5, 12, 30, 45, 1
         )
 
+    # def test_shift_imaginary(self):
+    #
+    #     just_before = arrow.Arrow(2013, 3, 31, 1, 59, 59, 999999, 'Europe/Paris')
+    #     just_after = just_before.shift(microseconds=+1)
+    #
+    #     assert just_after == arrow.Arrow(2013, 3, 31, 3, tzinfo='Europe/Paris')
+
+    def test_shift_positive_imaginary(self):
+
+        # Avoid shifting into imaginary datetimes, take into account DST and other timezone changes.
+
+        new_york = arrow.Arrow(2017, 3, 12, 1, 30, tzinfo="America/New_York")
+        assert new_york.shift(hours=+1) == arrow.Arrow(
+            2017, 3, 12, 3, 30, tzinfo="America/New_York"
+        )
+
+        # pendulum example
+        paris = arrow.Arrow(2013, 3, 31, 1, 50, tzinfo="Europe/Paris")
+        assert paris.shift(minutes=+20) == arrow.Arrow(
+            2013, 3, 31, 3, 10, tzinfo="Europe/Paris"
+        )
+
+        canberra = arrow.Arrow(2018, 10, 7, 1, 30, tzinfo="Australia/Canberra")
+        assert canberra.shift(hours=+1) == arrow.Arrow(
+            2018, 10, 7, 3, 30, tzinfo="Australia/Canberra"
+        )
+
+        kiev = arrow.Arrow(2018, 3, 25, 2, 30, tzinfo="Europe/Kiev")
+        assert kiev.shift(hours=+1) == arrow.Arrow(
+            2018, 3, 25, 4, 30, tzinfo="Europe/Kiev"
+        )
+
+        # Edge case, the entire day of 2011-12-30 is imaginary in this zone!
+        apia = arrow.Arrow(2011, 12, 29, 23, tzinfo="Pacific/Apia")
+        assert apia.shift(hours=+2) == arrow.Arrow(
+            2011, 12, 31, 1, tzinfo="Pacific/Apia"
+        )
+
+    def test_shift_negative_imaginary(self):
+
+        new_york = arrow.Arrow(2011, 3, 13, 3, 30, tzinfo="America/New_York")
+        assert new_york.shift(hours=-1) == arrow.Arrow(
+            2011, 3, 13, 3, 30, tzinfo="America/New_York"
+        )
+        assert new_york.shift(hours=-2) == arrow.Arrow(
+            2011, 3, 13, 1, 30, tzinfo="America/New_York"
+        )
+
+        # NOTE very odd behaviour here -<Arrow [2011-12-30T23:00:00+14:00]>
+        # How does dateutil.resolve_imaginary work here? This dt should be resolved in the shift method.
+
+        # dateutil says that the method will always fall forward.
+
+        # apia = arrow.Arrow(2011, 12, 31, 1, tzinfo="Pacific/Apia")
+        # assert apia.shift(hours=-2) == arrow.Arrow(
+        #    2011, 12, 29, 23, tzinfo="Pacific/Apia"deac
+        # )
+
+    @pytest.mark.skipif(
+        dateutil.__version__ < "2.7.1", reason="old tz database (2018d needed)"
+    )
+    def test_shift_kiritimati(self):
+        # corrected 2018d tz database release, will fail in earlier versions
+
+        kiritimati = arrow.Arrow(1994, 12, 30, 12, 30, tzinfo="Pacific/Kiritimati")
+        assert kiritimati.shift(days=+1) == arrow.Arrow(
+            1995, 1, 1, 12, 30, tzinfo="Pacific/Kiritimati"
+        )
+
+    @pytest.mark.skipif(
+        sys.version_info < (3, 6), reason="unsupported before python 3.6"
+    )
+    def shift_imaginary_seconds(self):
+        # offset has a seconds component
+        monrovia = arrow.Arrow(1972, 1, 6, 23, tzinfo="Africa/Monrovia")
+        assert monrovia.shift(hours=+1, minutes=+30) == arrow.Arrow(
+            1972, 1, 7, 1, 14, 30, tzinfo="Africa/Monrovia"
+        )
+
 
 class TestArrowRange:
     def test_year(self):
@@ -1026,6 +1114,18 @@ class TestArrowRange:
 
         for r in result:
             assert r.tzinfo == tz.gettz("US/Central")
+
+    def test_imaginary(self):
+        # issue #72, avoid duplication in utc column
+
+        before = arrow.Arrow(2018, 3, 10, 23, tzinfo="US/Pacific")
+        after = arrow.Arrow(2018, 3, 11, 4, tzinfo="US/Pacific")
+
+        pacific_range = [t for t in arrow.Arrow.range("hour", before, after)]
+        utc_range = [t.to("utc") for t in arrow.Arrow.range("hour", before, after)]
+
+        assert len(pacific_range) == len(set(pacific_range))
+        assert len(utc_range) == len(set(utc_range))
 
     def test_unsupported(self):
 

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -847,13 +847,6 @@ class TestArrowShift:
             2013, 5, 5, 12, 30, 45, 1
         )
 
-    # def test_shift_imaginary(self):
-    #
-    #     just_before = arrow.Arrow(2013, 3, 31, 1, 59, 59, 999999, 'Europe/Paris')
-    #     just_after = just_before.shift(microseconds=+1)
-    #
-    #     assert just_after == arrow.Arrow(2013, 3, 31, 3, tzinfo='Europe/Paris')
-
     def test_shift_positive_imaginary(self):
 
         # Avoid shifting into imaginary datetimes, take into account DST and other timezone changes.
@@ -895,15 +888,19 @@ class TestArrowShift:
             2011, 3, 13, 1, 30, tzinfo="America/New_York"
         )
 
-        # NOTE very odd behaviour here -<Arrow [2011-12-30T23:00:00+14:00]>
-        # How does dateutil.resolve_imaginary work here? This dt should be resolved in the shift method.
+        london = arrow.Arrow(2019, 3, 31, 2, tzinfo="Europe/London")
+        assert london.shift(hours=-1) == arrow.Arrow(
+            2019, 3, 31, 2, tzinfo="Europe/London"
+        )
+        assert london.shift(hours=-2) == arrow.Arrow(
+            2019, 3, 31, tzinfo="Europe/London"
+        )
 
-        # dateutil says that the method will always fall forward.
-
-        # apia = arrow.Arrow(2011, 12, 31, 1, tzinfo="Pacific/Apia")
-        # assert apia.shift(hours=-2) == arrow.Arrow(
-        #    2011, 12, 29, 23, tzinfo="Pacific/Apia"deac
-        # )
+        # edge case, crossing the international dateline
+        apia = arrow.Arrow(2011, 12, 31, 1, tzinfo="Pacific/Apia")
+        assert apia.shift(hours=-2) == arrow.Arrow(
+            2011, 12, 31, 23, tzinfo="Pacific/Apia"
+        )
 
     @pytest.mark.skipif(
         dateutil.__version__ < "2.7.1", reason="old tz database (2018d needed)"

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -893,7 +893,7 @@ class TestArrowShift:
             2019, 3, 31, 2, tzinfo="Europe/London"
         )
         assert london.shift(hours=-2) == arrow.Arrow(
-            2019, 3, 31, tzinfo="Europe/London"
+            2019, 3, 31, 0, tzinfo="Europe/London"
         )
 
         # edge case, crossing the international dateline


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets: [x] -->
- [x] 🧪 Added **tests** for changed code.
- [x] 🛠️ All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹 All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚 Updated **documentation** for changed code.
- [x] ⏩ Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

closes #72 

Pendulum example is now fixed.

```shell
(arrow) chris@ThinkPad:~/arrow$ python
Python 3.8.3 (default, Jul  7 2020, 18:57:36) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import arrow
>>> just_before = arrow.get(2013, 3, 31, 1, 55, "Europe/Paris")
>>> just_before = arrow.get(2013, 3, 31, 1, 55, tzinfo= "Europe/Paris")
>>> just_before
<Arrow [2013-03-31T01:55:00+01:00]>
>>> just_before.shift(minutes=+10)
<Arrow [2013-03-31T03:05:00+02:00]>
```

Range duplication no longer occurs.
```shell
>>> before = arrow.get('2018-03-10 23:00:00', 'YYYY-MM-DD HH:mm:ss', tzinfo='US/Pacific')
>>> after = arrow.get('2018-03-11 04:00:00', 'YYYY-MM-DD HH:mm:ss', tzinfo='US/Pacific')
>>> result=[ (t, t.to('utc')) for t in arrow.Arrow.range('hour', before, after) ]
>>> for r in result:
...     print(r)
... 
(<Arrow [2018-03-10T23:00:00-08:00]>, <Arrow [2018-03-11T07:00:00+00:00]>)
(<Arrow [2018-03-11T00:00:00-08:00]>, <Arrow [2018-03-11T08:00:00+00:00]>)
(<Arrow [2018-03-11T01:00:00-08:00]>, <Arrow [2018-03-11T09:00:00+00:00]>)
(<Arrow [2018-03-11T03:00:00-07:00]>, <Arrow [2018-03-11T10:00:00+00:00]>)
(<Arrow [2018-03-11T04:00:00-07:00]>, <Arrow [2018-03-11T11:00:00+00:00]>)
```

I was also considering wrapping dateutil's `resolve_imaginary` function as an utility method for our users.