### PR TITLE
Fix french locale

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -487,7 +487,7 @@ class FrenchBaseLocale(Locale):
     timeframes = {
         "now": "maintenant",
         "second": "une seconde",
-        "seconds": "{0} quelques secondes",
+        "seconds": "{0} secondes",
         "minute": "une minute",
         "minutes": "{0} minutes",
         "hour": "une heure",


### PR DESCRIPTION
Fixes:
```
(arrow.get() - timedelta(seconds=33)).humanize(locale="fr")
'il y a 33 quelques secondes'
```
Either say "a few seconds ago": "il y a quelques secondes" or "33 seconds ago": "il y a 33 secondes", not "a few 33 seconds ago"

## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [ ] 🧪  Added **tests** for changed code.
- [ ] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [ ] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [ ] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

<!--
Replace this commented text block with a description of your code changes.

If your PR has an associated issue, insert the issue number (e.g. #703) or directly link to the GitHub issue (e.g. https://github.com/arrow-py/arrow/issues/703).

Pro-tip: writing "Closes: #703" in the PR body will automatically close issue #703 when the PR is merged.
-->
