### PR TITLE
Remove lint and docs targets from tox envlist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.18.0
-envlist = py{py3,27,35,36,37,38,39},lint,docs
+envlist = py{py3,27,35,36,37,38,39}
 skip_missing_interpreters = true
 
 [gh-actions]


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [ ] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes
Removes lint and docs targets from the tox envlist. This will allow folks to run all tests on the distribution tarball using tox with a simple `tox` command. Our linting suite requires pre-commit, which fails outside of a git repository, so it is probably best to leave out the linting related targets and instead invoke them manually via `tox -e lint` and `tox -e docs`.

Closes: https://github.com/arrow-py/arrow/issues/864
Closes: https://github.com/arrow-py/arrow/issues/869
<!--
Replace this commented text block with a description of your code changes.

If your PR has an associated issue, insert the issue number (e.g. #703) or directly link to the GitHub issue (e.g. https://github.com/arrow-py/arrow/issues/703).

Pro-tip: writing "Closes: #703" in the PR body will automatically close issue #703 when the PR is merged.
-->
