### PR TITLE
Change return value of Arrow __repr__ method

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -588,7 +588,23 @@ class Arrow:
     # representations
 
     def __repr__(self):
-        return f"<{self.__class__.__name__} [{self.__str__()}]>"
+
+        attrs = [
+            self.year,
+            self.month,
+            self.day,
+            self.hour,
+            self.minute,
+            self.second,
+            self.microsecond,
+            f"tzinfo={self.tzinfo}",
+        ]
+        attr_str = ", ".join(map(str, attrs))
+
+        if self.fold:
+            attr_str = attr_str[:-1] + ", fold=1)"
+
+        return f"{self.__class__.__name__}({attr_str})"
 
     def __str__(self):
         return self._datetime.isoformat()

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -595,16 +595,21 @@ class Arrow:
             self.day,
             self.hour,
             self.minute,
-            self.second,
-            self.microsecond,
-            f"tzinfo={self.tzinfo}",
         ]
-        attr_str = ", ".join(map(str, attrs))
+
+        if any([self.second, self.microsecond]):
+            attrs.append(self.second)
+            attrs.append(self.microsecond)
+
+        attrs.append(f"tzinfo={self.tzinfo}")
 
         if self.fold:
-            attr_str = attr_str[:-1] + ", fold=1)"
+            # only show if fold=1
+            attrs.append(f"fold={self.fold}")
 
-        return f"{self.__class__.__name__}({attr_str})"
+        attr_str = ", ".join(map(str, attrs))
+
+        return f"{__package__}.{self.__class__.__name__}({attr_str})"
 
     def __str__(self):
         return self._datetime.isoformat()

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -189,7 +189,20 @@ class TestTestArrowRepresentation:
 
         result = self.arrow.__repr__()
 
-        assert result == f"<Arrow [{self.arrow._datetime.isoformat()}]>"
+        assert result == "arrow.Arrow(2013, 2, 3, 12, 30, 45, 1, tzinfo=tzutc())"
+
+    def test_repr_with_fold(self):
+
+        arw_with_fold = arrow.Arrow(
+            2017, 10, 29, 2, 0, tzinfo="Europe/Stockholm", fold=1
+        )
+
+        result = arw_with_fold.__repr__()
+
+        assert (
+            result
+            == "arrow.Arrow(2017, 10, 29, 2, 0, tzinfo=tzfile('/usr/share/zoneinfo/Europe/Stockholm'), fold=1)"
+        )
 
     def test_str(self):
 

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -1,3 +1,4 @@
+import os
 import pickle
 import sys
 import time
@@ -191,6 +192,9 @@ class TestTestArrowRepresentation:
 
         assert result == "arrow.Arrow(2013, 2, 3, 12, 30, 45, 1, tzinfo=tzutc())"
 
+    @pytest.mark.skipif(
+        os.name == "nt", reason="tzfile repr is different on Windows and Linux"
+    )
     def test_repr_with_fold(self):
 
         arw_with_fold = arrow.Arrow(
@@ -202,6 +206,22 @@ class TestTestArrowRepresentation:
         assert (
             result
             == "arrow.Arrow(2017, 10, 29, 2, 0, tzinfo=tzfile('/usr/share/zoneinfo/Europe/Stockholm'), fold=1)"
+        )
+
+    @pytest.mark.skipif(
+        os.name == "posix", reason="tzfile repr is different on Windows and Linux"
+    )
+    def test_repr_with_fold_windows(self):
+
+        arw_with_fold = arrow.Arrow(
+            2017, 10, 29, 2, 0, tzinfo="Europe/Stockholm", fold=1
+        )
+
+        result = arw_with_fold.__repr__()
+
+        assert (
+            result
+            == "arrow.Arrow(2017, 10, 29, 2, 0, tzinfo=tzfile('Europe/Stockholm'), fold=1)"
         )
 
     def test_str(self):


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [ ] 🧪  Added **tests** for changed code.
- [ ] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [ ] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes
Needs tests updating and cleanup.

Things to discuss.
- All attributes are shown even if zero.
- `fold` is only shown if set to 1, this follows `datetime` repr.
- Maybe we should show `arrow.Arrow(....`?

Old style repr - `<Arrow [2013-05-05T12:30:45+00:00]>`

New style repr.
```shell
(arrow) chris@ThinkPad:~/arrow$ python
Python 3.8.3 (default, Jul  7 2020, 18:57:36) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import arrow
>>> arw=arrow.utcnow()
>>> arw
Arrow(2020, 11, 15, 16, 5, 43, 160053, tzinfo=tzutc())
>>> print(arw)
2020-11-15T16:05:43.160053+00:00
>>> dt_with_fold=arrow.get(2017, 10, 29, 1, 0, 0, tzinfo='Europe/Berlin', fold=0)
>>> dt_with_fold
Arrow(2017, 10, 29, 1, 0, 0, 0, tzinfo=tzfile('/usr/share/zoneinfo/Europe/Berlin'))
>>> dt_with_fold=arrow.get(2017, 10, 29, 1, 0, 0, tzinfo='Europe/Berlin', fold=1)
>>> dt_with_fold
Arrow(2017, 10, 29, 1, 0, 0, 0, tzinfo=tzfile('/usr/share/zoneinfo/Europe/Berlin', fold=1))
```

closes #834 
