### PR TITLE
Add 'exact' keyword in span_range, span and interval methods 

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -387,7 +387,10 @@ class Arrow:
             whether to include or exclude the start and end values in the span. '(' excludes
             the start, '[' includes the start, ')' excludes the end, and ']' includes the end.
             If the bounds are not specified, the default bound '[)' is used.
-        :param exact: (optional) whether to return a timespan that starts exacly at specificed start
+        :param exact: (optional) whether to have the start of the timespan begin exactly
+            at the time specified by ``start`` and the end of the timespan truncated
+            so as not to extend beyond ``end``.
+
         Supported frame values: year, quarter, month, week, day, hour, minute, second.
 
         Usage::

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -546,7 +546,9 @@ class Arrow:
                     if bounds[1] == ")":
                         ceil += relativedelta(microseconds=-1)
                 if floor == end:
-                    break  # TODO: implementation: break OR yield floor, floor IF bounds[1] == ")"
+                    break  # TODO: implementation detail: break OR yield floor, floor IF bounds[1] == "]"
+                elif floor + relativedelta(microseconds=-1) == end:
+                    break
                 yield floor, ceil
             else:
                 yield r.span(frame, bounds=bounds, exact=exact)

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -541,20 +541,21 @@ class Arrow:
         start = cls.fromdatetime(start, tzinfo).span(frame, exact=exact)[0]
         end = cls.fromdatetime(end, tzinfo)
         _range = cls.range(frame, start, end, tz, limit)
-        for r in _range:
-            if exact:
-                floor, ceil = r.span(frame, bounds=bounds, exact=exact)
-                if ceil > end:
-                    ceil = end
-                    if bounds[1] == ")":
-                        ceil += relativedelta(microseconds=-1)
-                if floor == end:
-                    break  # TODO: implementation detail: break OR yield floor, floor IF bounds[1] == "]"
-                elif floor + relativedelta(microseconds=-1) == end:
-                    break
-                yield floor, ceil
-            else:
+        if not exact:
+            for r in _range:
                 yield r.span(frame, bounds=bounds, exact=exact)
+
+        for r in _range:
+            floor, ceil = r.span(frame, bounds=bounds, exact=exact)
+            if ceil > end:
+                ceil = end
+                if bounds[1] == ")":
+                    ceil += relativedelta(microseconds=-1)
+            if floor == end:
+                break
+            elif floor + relativedelta(microseconds=-1) == end:
+                break
+            yield floor, ceil
 
     @classmethod
     def interval(cls, frame, start, end, interval=1, tz=None, bounds="[)", exact=False):

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -1493,7 +1493,7 @@ class TestArrowSpanRange:
 
         assert result == expected
 
-    def test_exact_bound_exclude2(self):
+    def test_exact_floor_equals_end(self):
         result = list(
             arrow.Arrow.span_range(
                 "minute",
@@ -1544,10 +1544,58 @@ class TestArrowSpanRange:
                 arrow.Arrow(2013, 5, 5, 12, 39),
                 arrow.Arrow(2013, 5, 5, 12, 39, 59, 999999),
             ),
-            # (
-            #     arrow.Arrow(2013, 5, 5, 12, 40),
-            #     arrow.Arrow(2013, 5, 5, 12, 39, 59, 999999),
-            # ),
+        ]
+
+        assert result == expected
+
+    def test_exact_bound_include(self):
+        result = list(
+            arrow.Arrow.span_range(
+                "hour",
+                datetime(2013, 5, 5, 2, 30),
+                datetime(2013, 5, 5, 6, 00),
+                bounds="(]",
+                exact=True,
+            )
+        )
+
+        expected = [
+            (
+                arrow.Arrow(2013, 5, 5, 2, 30, 00, 1),
+                arrow.Arrow(2013, 5, 5, 3, 30, 00, 0),
+            ),
+            (
+                arrow.Arrow(2013, 5, 5, 3, 30, 00, 1),
+                arrow.Arrow(2013, 5, 5, 4, 30, 00, 0),
+            ),
+            (
+                arrow.Arrow(2013, 5, 5, 4, 30, 00, 1),
+                arrow.Arrow(2013, 5, 5, 5, 30, 00, 0),
+            ),
+            (
+                arrow.Arrow(2013, 5, 5, 5, 30, 00, 1),
+                arrow.Arrow(2013, 5, 5, 6, 00),
+            ),
+        ]
+
+        assert result == expected
+
+    def test_small_interval_exact_open_bounds(self):
+        result = list(
+            arrow.Arrow.span_range(
+                "minute",
+                datetime(2013, 5, 5, 2, 30),
+                datetime(2013, 5, 5, 2, 31),
+                bounds="()",
+                exact=True,
+            )
+        )
+
+        expected = [
+            (
+                arrow.Arrow(2013, 5, 5, 2, 30, 00, 1),
+                arrow.Arrow(2013, 5, 5, 2, 30, 59, 999999),
+            ),
         ]
 
         assert result == expected

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -1801,6 +1801,34 @@ class TestArrowSpan:
         assert result_floor == expected_floor
         assert result_ceil == expected_ceil
 
+    def test_exact_inclusive_inclusive(self):
+
+        floor, ceil = self.arrow.span("minute", bounds="[]", exact=True)
+
+        assert floor == datetime(2013, 2, 15, 3, 41, 22, 8923, tzinfo=tz.tzutc())
+        assert ceil == datetime(2013, 2, 15, 3, 42, 22, 8923, tzinfo=tz.tzutc())
+
+    def test_exact_exclusive_inclusive(self):
+
+        floor, ceil = self.arrow.span("day", bounds="(]", exact=True)
+
+        assert floor == datetime(2013, 2, 15, 3, 41, 22, 8924, tzinfo=tz.tzutc())
+        assert ceil == datetime(2013, 2, 16, 3, 41, 22, 8923, tzinfo=tz.tzutc())
+
+    def test_exact_exclusive_exclusive(self):
+
+        floor, ceil = self.arrow.span("second", bounds="()", exact=True)
+
+        assert floor == datetime(2013, 2, 15, 3, 41, 22, 8924, tzinfo=tz.tzutc())
+        assert ceil == datetime(2013, 2, 15, 3, 41, 23, 8922, tzinfo=tz.tzutc())
+
+    def test_all_parameters_specified(self):
+
+        floor, ceil = self.arrow.span("week", bounds="()", exact=True, count=2)
+
+        assert floor == datetime(2013, 2, 15, 3, 41, 22, 8924, tzinfo=tz.tzutc())
+        assert ceil == datetime(2013, 3, 1, 3, 41, 22, 8922, tzinfo=tz.tzutc())
+
 
 @pytest.mark.usefixtures("time_2013_01_01")
 class TestArrowHumanize:

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -1456,6 +1456,102 @@ class TestArrowSpanRange:
             (arrow.Arrow(2013, 4, 1), arrow.Arrow(2013, 7, 1)),
         ]
 
+    def test_exact_bound_exclude(self):
+
+        result = list(
+            arrow.Arrow.span_range(
+                "hour",
+                datetime(2013, 5, 5, 12, 30),
+                datetime(2013, 5, 5, 17, 15),
+                bounds="[)",
+                exact=True,
+            )
+        )
+
+        expected = [
+            (
+                arrow.Arrow(2013, 5, 5, 12, 30),
+                arrow.Arrow(2013, 5, 5, 13, 29, 59, 999999),
+            ),
+            (
+                arrow.Arrow(2013, 5, 5, 13, 30),
+                arrow.Arrow(2013, 5, 5, 14, 29, 59, 999999),
+            ),
+            (
+                arrow.Arrow(2013, 5, 5, 14, 30),
+                arrow.Arrow(2013, 5, 5, 15, 29, 59, 999999),
+            ),
+            (
+                arrow.Arrow(2013, 5, 5, 15, 30),
+                arrow.Arrow(2013, 5, 5, 16, 29, 59, 999999),
+            ),
+            (
+                arrow.Arrow(2013, 5, 5, 16, 30),
+                arrow.Arrow(2013, 5, 5, 17, 14, 59, 999999),
+            ),
+        ]
+
+        assert result == expected
+
+    def test_exact_bound_exclude2(self):
+        result = list(
+            arrow.Arrow.span_range(
+                "minute",
+                datetime(2013, 5, 5, 12, 30),
+                datetime(2013, 5, 5, 12, 40),
+                exact=True,
+            )
+        )
+
+        expected = [
+            (
+                arrow.Arrow(2013, 5, 5, 12, 30),
+                arrow.Arrow(2013, 5, 5, 12, 30, 59, 999999),
+            ),
+            (
+                arrow.Arrow(2013, 5, 5, 12, 31),
+                arrow.Arrow(2013, 5, 5, 12, 31, 59, 999999),
+            ),
+            (
+                arrow.Arrow(2013, 5, 5, 12, 32),
+                arrow.Arrow(2013, 5, 5, 12, 32, 59, 999999),
+            ),
+            (
+                arrow.Arrow(2013, 5, 5, 12, 33),
+                arrow.Arrow(2013, 5, 5, 12, 33, 59, 999999),
+            ),
+            (
+                arrow.Arrow(2013, 5, 5, 12, 34),
+                arrow.Arrow(2013, 5, 5, 12, 34, 59, 999999),
+            ),
+            (
+                arrow.Arrow(2013, 5, 5, 12, 35),
+                arrow.Arrow(2013, 5, 5, 12, 35, 59, 999999),
+            ),
+            (
+                arrow.Arrow(2013, 5, 5, 12, 36),
+                arrow.Arrow(2013, 5, 5, 12, 36, 59, 999999),
+            ),
+            (
+                arrow.Arrow(2013, 5, 5, 12, 37),
+                arrow.Arrow(2013, 5, 5, 12, 37, 59, 999999),
+            ),
+            (
+                arrow.Arrow(2013, 5, 5, 12, 38),
+                arrow.Arrow(2013, 5, 5, 12, 38, 59, 999999),
+            ),
+            (
+                arrow.Arrow(2013, 5, 5, 12, 39),
+                arrow.Arrow(2013, 5, 5, 12, 39, 59, 999999),
+            ),
+            # (
+            #     arrow.Arrow(2013, 5, 5, 12, 40),
+            #     arrow.Arrow(2013, 5, 5, 12, 39, 59, 999999),
+            # ),
+        ]
+
+        assert result == expected
+
 
 class TestArrowInterval:
     def test_incorrect_input(self):
@@ -1504,6 +1600,30 @@ class TestArrowInterval:
             (arrow.Arrow(2013, 5, 5, 14), arrow.Arrow(2013, 5, 5, 16)),
             (arrow.Arrow(2013, 5, 5, 16), arrow.Arrow(2013, 5, 5, 18)),
         ]
+
+    def test_exact(self):
+        result = list(
+            arrow.Arrow.interval(
+                "hour",
+                datetime(2013, 5, 5, 12, 30),
+                datetime(2013, 5, 5, 17, 15),
+                4,
+                exact=True,
+            )
+        )
+
+        expected = [
+            (
+                arrow.Arrow(2013, 5, 5, 12, 30),
+                arrow.Arrow(2013, 5, 5, 16, 29, 59, 999999),
+            ),
+            (
+                arrow.Arrow(2013, 5, 5, 16, 30),
+                arrow.Arrow(2013, 5, 5, 17, 14, 59, 999999),
+            ),
+        ]
+
+        assert result == expected
 
 
 @pytest.mark.usefixtures("time_2013_02_15")
@@ -1622,6 +1742,16 @@ class TestArrowSpan:
 
         with pytest.raises(ValueError):
             floor, ceil = self.arrow.span("hour", bounds="][")
+
+    def test_exact(self):
+
+        result_floor, result_ceil = self.arrow.span("hour", exact=True)
+
+        expected_floor = datetime(2013, 2, 15, 3, 41, 22, 8923, tzinfo=tz.tzutc())
+        expected_ceil = datetime(2013, 2, 15, 4, 41, 22, 8922, tzinfo=tz.tzutc())
+
+        assert result_floor == expected_floor
+        assert result_ceil == expected_ceil
 
 
 @pytest.mark.usefixtures("time_2013_01_01")


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [x] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

Merged PR #817 with updated master. Added edge cases in span_range function when exact keyword is True. Added correlated tests for span_range. 

Closes: #498 