### PR TITLE
fix edge case for humanize month

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -1045,7 +1045,9 @@ class Arrow:
                 elif diff < self._SECS_PER_MONTH:
                     weeks = sign * int(max(delta / self._SECS_PER_WEEK, 2))
                     if abs(weeks) == 4:
-                        return locale.describe("month", sign, only_distance=only_distance)
+                        return locale.describe(
+                            "month", sign, only_distance=only_distance
+                            )
                     return locale.describe("weeks", weeks, only_distance=only_distance)
 
                 elif diff < self._SECS_PER_MONTH * 2:

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -1047,7 +1047,7 @@ class Arrow:
                     if abs(weeks) == 4:
                         return locale.describe(
                             "month", sign, only_distance=only_distance
-                            )
+                        )
                     return locale.describe("weeks", weeks, only_distance=only_distance)
 
                 elif diff < self._SECS_PER_MONTH * 2:

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -1044,6 +1044,8 @@ class Arrow:
                     return locale.describe("week", sign, only_distance=only_distance)
                 elif diff < self._SECS_PER_MONTH:
                     weeks = sign * int(max(delta / self._SECS_PER_WEEK, 2))
+                    if abs(weeks) == 4:
+                        return locale.describe("month", sign, only_distance=only_distance)
                     return locale.describe("weeks", weeks, only_distance=only_distance)
 
                 elif diff < self._SECS_PER_MONTH * 2:

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -2135,7 +2135,7 @@ class TestArrowHumanize:
 
         for month in range(1, 12):
             earlier_30days = arrow.Arrow.fromdatetime(datetime(2020, month, 3))
-            later_30days = arrow.Arrow.fromdatetime(datetime(2020, month+1, 3))
+            later_30days = arrow.Arrow.fromdatetime(datetime(2020, month + 1, 3))
             assert earlier_30days.humanize(later_30days) == "a month ago"
             assert later_30days.humanize(earlier_30days) == "in a month"
 
@@ -2144,7 +2144,6 @@ class TestArrowHumanize:
         later_30days = arrow.Arrow.fromdatetime(datetime(2021, 1, 3))
         assert earlier_30days.humanize(later_30days) == "a month ago"
         assert later_30days.humanize(earlier_30days) == "in a month"
-
 
     def test_year(self):
 

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -2131,6 +2131,21 @@ class TestArrowHumanize:
         assert self.now.humanize(later, only_distance=True) == "2 months"
         assert later.humanize(self.now, only_distance=True) == "2 months"
 
+    def test_edgecase_months(self):
+
+        for month in range(1, 12):
+            earlier_30days = arrow.Arrow.fromdatetime(datetime(2020, month, 3))
+            later_30days = arrow.Arrow.fromdatetime(datetime(2020, month+1, 3))
+            assert earlier_30days.humanize(later_30days) == "a month ago"
+            assert later_30days.humanize(earlier_30days) == "in a month"
+
+        # test Dec && Jan
+        earlier_30days = arrow.Arrow.fromdatetime(datetime(2020, 12, 3))
+        later_30days = arrow.Arrow.fromdatetime(datetime(2021, 1, 3))
+        assert earlier_30days.humanize(later_30days) == "a month ago"
+        assert later_30days.humanize(earlier_30days) == "in a month"
+
+
     def test_year(self):
 
         later = self.now.shift(years=1)

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -2134,16 +2134,16 @@ class TestArrowHumanize:
     def test_edgecase_months(self):
 
         for month in range(1, 12):
-            earlier_30days = arrow.Arrow.fromdatetime(datetime(2020, month, 3))
-            later_30days = arrow.Arrow.fromdatetime(datetime(2020, month + 1, 3))
-            assert earlier_30days.humanize(later_30days) == "a month ago"
-            assert later_30days.humanize(earlier_30days) == "in a month"
+            earlier = arrow.Arrow.fromdatetime(datetime(2020, month, 3))
+            later = arrow.Arrow.fromdatetime(datetime(2020, month + 1, 3))
+            assert earlier.humanize(later) == "a month ago"
+            assert later.humanize(earlier) == "in a month"
 
         # test Dec && Jan
-        earlier_30days = arrow.Arrow.fromdatetime(datetime(2020, 12, 3))
-        later_30days = arrow.Arrow.fromdatetime(datetime(2021, 1, 3))
-        assert earlier_30days.humanize(later_30days) == "a month ago"
-        assert later_30days.humanize(earlier_30days) == "in a month"
+        earlier = arrow.Arrow.fromdatetime(datetime(2020, 12, 3))
+        later = arrow.Arrow.fromdatetime(datetime(2021, 1, 3))
+        assert earlier.humanize(later) == "a month ago"
+        assert later.humanize(earlier) == "in a month"
 
     def test_year(self):
 


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [x] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

## Description of Changes

<!--
Replace this commented text block with a description of your code changes.

If your PR has an associated issue, insert the issue number (e.g. #703) or directly link to the GitHub issue (e.g. https://github.com/arrow-py/arrow/issues/703).

Pro-tip: writing "Closes: #703" in the PR body will automatically close issue #703 when the PR is merged.
-->

Added edge case handling for the ```humanize``` method to describe the delta of both 30 days and 31 days as "1 month". 

For instance, 
```
dt=arrow.get("2020-11-08T15:12:18.911919+00:00")
later=dt.shift(months=+1)
print(dt.humanize(later))
print(later.humanize(dt))
```
should print
```
a month ago
in a month
```


Closes: #749