### PR TITLE
Fix simple docs typo, inpute -> input

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -5,7 +5,7 @@ from math import trunc
 
 def get_locale(name):
     """Returns an appropriate :class:`Locale <arrow.locales.Locale>`
-    corresponding to an inpute locale name.
+    corresponding to an input locale name.
 
     :param name: the name of the locale.
 


### PR DESCRIPTION
There is a small typo in arrow/locales.py.

Should read `input` rather than `inpute`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md