### PR TITLE
Remove tzinfo.setter and update tests

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -696,12 +696,6 @@ class Arrow:
 
         return self._datetime.tzinfo
 
-    @tzinfo.setter
-    def tzinfo(self, tzinfo):
-        """ Sets the ``tzinfo`` of the :class:`Arrow <arrow.arrow.Arrow>` object. """
-
-        self._datetime = self._datetime.replace(tzinfo=tzinfo)
-
     @property
     def datetime(self):
         """Returns a datetime representation of the :class:`Arrow <arrow.arrow.Arrow>` object.

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -285,8 +285,7 @@ class TestArrowAttribute:
 
     def test_tzinfo(self):
 
-        self.arrow.tzinfo = tz.gettz("PST")
-        assert self.arrow.tzinfo == tz.gettz("PST")
+        assert self.arrow.tzinfo == tz.tzutc()
 
     def test_naive(self):
 


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [ ] 🧪  Added **tests** for changed code.
- [ ] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [ ] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [ ] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

Removing the `tzinfo.setter` to help with hashing and consistency.

```shell
(arrow) chris@ThinkPad:~/arrow$ python
Python 3.8.3 (default, Jul  7 2020, 18:57:36) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from dateutil import tz
>>> import arrow
>>> dt=arrow.utcnow()
>>> dt.tzinfo=tz.gettz("US/Pacific")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: can't set attribute
>>> dt.replace(tzinfo=tz.gettz("US/Pacific"))
<Arrow [2020-12-22T16:03:29.630250-08:00]>
```