### PR TITLE
Adding locale validation for timeframes, meridians and and_word.

### DIFF
--- a/tests/test_locales.py
+++ b/tests/test_locales.py
@@ -8,7 +8,24 @@ class TestLocaleValidation:
     """Validate locales to ensure that translations are valid and complete"""
 
     def test_locale_validation(self):
-
+        timeframe_test = [
+            "now",
+            "second",
+            "seconds",
+            "minute",
+            "minutes",
+            "hour",
+            "hours",
+            "day",
+            "days",
+            "week",
+            "weeks",
+            "month",
+            "months",
+            "year",
+            "years",
+        ]
+        meridian_test = ["am", "pm", "AM", "PM"]
         for _, locale_cls in self.locales.items():
             # 7 days + 1 spacer to allow for 1-indexing of months
             assert len(locale_cls.day_names) == 8
@@ -32,6 +49,15 @@ class TestLocaleValidation:
             assert len(locale_cls.names) > 0
             assert locale_cls.past is not None
             assert locale_cls.future is not None
+            assert locale_cls.and_word is not None
+
+            for timeframe in timeframe_test:
+                assert timeframe in locale_cls.timeframes
+                assert locale_cls.timeframes[timeframe] != ""
+
+            for meridian in meridian_test:
+                assert meridian in locale_cls.meridians
+                assert locale_cls.meridians[meridian] != ""
 
 
 class TestModule:


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [ ] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [ ] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [ ] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

Updating the locale validation test to check for the newly added timeframes that have been added, as well as meridians and and_word.

It would be nice to have this.. as it would give some indication of locales that aren't in compliance or usable even with the latest version, but it would break the tests.

So up for debate, do we add an xfail in this or try to get all the locales up to par?