### PR TITLE
Correct Norwegian grammar

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -1853,8 +1853,8 @@ class NorwegianLocale(Locale):
 
     timeframes = {
         "now": "nå nettopp",
-        "second": "et sekund",
-        "seconds": "{0} noen sekunder",
+        "second": "ett sekund",
+        "seconds": "{0} sekunder",
         "minute": "ett minutt",
         "minutes": "{0} minutter",
         "hour": "en time",
@@ -1920,9 +1920,9 @@ class NewNorwegianLocale(Locale):
 
     timeframes = {
         "now": "no nettopp",
-        "second": "et sekund",
-        "seconds": "{0} nokre sekund",
-        "minute": "ett minutt",
+        "second": "eitt sekund",
+        "seconds": "{0} sekund",
+        "minute": "eitt minutt",
         "minutes": "{0} minutt",
         "hour": "ein time",
         "hours": "{0} timar",
@@ -1930,7 +1930,7 @@ class NewNorwegianLocale(Locale):
         "days": "{0} dagar",
         "month": "en månad",
         "months": "{0} månader",
-        "year": "eit år",
+        "year": "eitt år",
         "years": "{0} år",
     }
 


### PR DESCRIPTION
## Pull Request Checklist

- [ ] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

## Description of Changes

Removed a word that was left over from a previous refactoring. By mistake, somebody had changed `noen sekunder` to  `{0} noen sekunder` (lit. translated: `some seconds` -> `{0} some seconds`).

Also corrected some of the Norwegian strings, e.g. "et" -> "ett" (lit. translated: "a" -> "one"), for both variants.