### PR TITLE
Add py.typed export per PEP 561

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     author_email="crsmithdev@gmail.com",
     license="Apache 2.0",
     packages=["arrow"],
+    package_data={"arrow": ["py.typed"]},
     zip_safe=False,
     python_requires=">=3.6",
     install_requires=[


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [ ] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

Add `py.typed` file and export type annotations per [PEP 561](https://www.python.org/dev/peps/pep-0561/) so that type testing tools like mypy can actually verify types when using arrow.

No new test added for this change and I don't think there's any documentation necessary but let me know if something needs to be added.