### PR TITLE
Swedish locale fix

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -788,7 +788,7 @@ class SwedishLocale(Locale):
     timeframes = {
         "now": "just nu",
         "second": "en sekund",
-        "seconds": "{0} några sekunder",
+        "seconds": "{0} sekunder",
         "minute": "en minut",
         "minutes": "{0} minuter",
         "hour": "en timme",

--- a/tests/test_locales.py
+++ b/tests/test_locales.py
@@ -1367,3 +1367,22 @@ class TestJapaneseLocale:
         assert self.locale._format_timeframe("months", 11) == "11ヶ月"
         assert self.locale._format_timeframe("year", 1) == "1年"
         assert self.locale._format_timeframe("years", 12) == "12年"
+
+@pytest.mark.usefixtures("lang_locale")
+class TestSwedishLocale:
+    def test_plurals(self):
+        assert self.locale._format_timeframe("now", 0) == "just nu"
+        assert self.locale._format_timeframe("second", 1) == "en sekund"
+        assert self.locale._format_timeframe("seconds", 30) == "30 sekunder"
+        assert self.locale._format_timeframe("minute", 1) == "en minut"
+        assert self.locale._format_timeframe("minutes", 40) == "40 minuter"
+        assert self.locale._format_timeframe("hour", 1) == "en timme"
+        assert self.locale._format_timeframe("hours", 23) == "23 timmar"
+        assert self.locale._format_timeframe("day", 1) == "en dag"
+        assert self.locale._format_timeframe("days", 12) == "12 dagar"
+        assert self.locale._format_timeframe("week", 1) == "en vecka"
+        assert self.locale._format_timeframe("weeks", 38) == "38 veckor"
+        assert self.locale._format_timeframe("month", 1) == "en månad"
+        assert self.locale._format_timeframe("months", 11) == "11 månader"
+        assert self.locale._format_timeframe("year", 1) == "ett år"
+        assert self.locale._format_timeframe("years", 12) == "12 år"

--- a/tests/test_locales.py
+++ b/tests/test_locales.py
@@ -1368,6 +1368,7 @@ class TestJapaneseLocale:
         assert self.locale._format_timeframe("year", 1) == "1年"
         assert self.locale._format_timeframe("years", 12) == "12年"
 
+
 @pytest.mark.usefixtures("lang_locale")
 class TestSwedishLocale:
     def test_plurals(self):


### PR DESCRIPTION
Removed "några" from seconds. That is not how we write it.

## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [x] 🧪  Added **tests** for changed code.
- [ ] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

Just a small wording change for swedish locale.

Added TestSwedishLocale

tox tests fails due to master not having 100% test coverage. (99.80%)