### PR TITLE
Reconfigure arrow/__init__.py to avoid mypy --strict problems

### DIFF
--- a/arrow/__init__.py
+++ b/arrow/__init__.py
@@ -16,6 +16,8 @@ from .formatter import (
 )
 from .parser import ParserError
 
+# https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-implicit-reexport
+# Mypy with --strict or --no-implicit-reexport requires an explizit reexport.
 __all__ = [
     "__version__",
     "get",
@@ -33,4 +35,5 @@ __all__ = [
     "FORMAT_RFC3339",
     "FORMAT_RSS",
     "FORMAT_W3C",
+    "ParserError",
 ]

--- a/arrow/__init__.py
+++ b/arrow/__init__.py
@@ -17,7 +17,7 @@ from .formatter import (
 from .parser import ParserError
 
 # https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-implicit-reexport
-# Mypy with --strict or --no-implicit-reexport requires an explizit reexport.
+# Mypy with --strict or --no-implicit-reexport requires an explicit reexport.
 __all__ = [
     "__version__",
     "get",

--- a/arrow/__init__.py
+++ b/arrow/__init__.py
@@ -15,3 +15,22 @@ from .formatter import (
     FORMAT_W3C,
 )
 from .parser import ParserError
+
+__all__ = [
+    "__version__",
+    "get",
+    "now",
+    "utcnow",
+    "Arrow",
+    "ArrowFactory",
+    "FORMAT_ATOM",
+    "FORMAT_COOKIE",
+    "FORMAT_RFC822",
+    "FORMAT_RFC850",
+    "FORMAT_RFC1036",
+    "FORMAT_RFC1123",
+    "FORMAT_RFC2822",
+    "FORMAT_RFC3339",
+    "FORMAT_RSS",
+    "FORMAT_W3C",
+]


### PR DESCRIPTION
Mypy prevents the implicit reexport, when --no-implicit-reexport is given.

## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [ ] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [ ] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

Mypy in combination with `--strict` or `--no-implicit-reexport` prevents implicit reexport, as it was done in `arrow.__init__`. See https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-implicit-reexport for details.

This can be either solved by defining `__all__` (this pull request) or by using `as` in the import statements (e.g. `from .api import get as get`).

If you prefer the later version, I can prepare another pull request.
