### PR TITLE
Update docstring to not use the timestamp method as a property

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -849,7 +849,7 @@ class Arrow:
 
         Usage::
 
-            >>> arrow.utcnow().timestamp
+            >>> arrow.utcnow().timestamp()
             1548260567
 
         """


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [ ] 🧪  Added **tests** for changed code.
- [ ] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [ ] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [x] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

Minor fix: An example in the docstring of the `timestamp` method was still using it as a property, which is no longer supported; changed it to a function call instead.