### PR TITLE
Improve _format_timeframe type annotations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,16 +16,16 @@ repos:
       - id: check-merge-conflict
       - id: debug-statements
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.8.0
+    rev: 5.9.1
     hooks:
       - id: isort
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.16.0
+    rev: v2.19.4
     hooks:
       - id: pyupgrade
         args: [--py36-plus]
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.8.0
+    rev: v1.9.0
     hooks:
       - id: python-no-eval
       - id: python-check-blanket-noqa
@@ -34,7 +34,7 @@ repos:
       - id: rst-directive-colons
       - id: rst-inline-touching-normal
   - repo: https://github.com/psf/black
-    rev: 21.5b1
+    rev: 21.6b0
     hooks:
       - id: black
         args: [--safe, --quiet, --target-version=py36]
@@ -44,6 +44,7 @@ repos:
       - id: flake8
         additional_dependencies: [flake8-bugbear]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.812'
+    rev: 'v0.910'
     hooks:
       - id: mypy
+        additional_dependencies: [types-python-dateutil]

--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -268,9 +268,7 @@ class Locale:
     def _name_to_ordinal(self, lst: Sequence[str]) -> Dict[str, int]:
         return {elem.lower(): i for i, elem in enumerate(lst[1:], 1)}
 
-    def _format_timeframe(
-        self, timeframe: TimeFrameLiteral, delta: Union[float, int]
-    ) -> str:
+    def _format_timeframe(self, timeframe: TimeFrameLiteral, delta: int) -> str:
         # TODO: remove cast
         return cast(str, self.timeframes[timeframe]).format(trunc(abs(delta)))
 
@@ -927,7 +925,7 @@ class FinnishLocale(Locale):
     day_abbreviations = ["", "ma", "ti", "ke", "to", "pe", "la", "su"]
 
     # TODO: Fix return type
-    def _format_timeframe(self, timeframe: TimeFrameLiteral, delta: Union[float, int]) -> Tuple[str, str]:  # type: ignore
+    def _format_timeframe(self, timeframe: TimeFrameLiteral, delta: int) -> Tuple[str, str]:  # type: ignore
         return (
             self.timeframes[timeframe][0].format(abs(delta)),
             self.timeframes[timeframe][1].format(abs(delta)),
@@ -1302,9 +1300,7 @@ class DutchLocale(Locale):
 class SlavicBaseLocale(Locale):
     timeframes: ClassVar[Mapping[TimeFrameLiteral, Union[str, List[str]]]]
 
-    def _format_timeframe(
-        self, timeframe: TimeFrameLiteral, delta: Union[float, int]
-    ) -> str:
+    def _format_timeframe(self, timeframe: TimeFrameLiteral, delta: int) -> str:
         form = self.timeframes[timeframe]
         delta = abs(delta)
 
@@ -2518,9 +2514,7 @@ class ArabicLocale(Locale):
     ]
     day_abbreviations = ["", "إثنين", "ثلاثاء", "أربعاء", "خميس", "جمعة", "سبت", "أحد"]
 
-    def _format_timeframe(
-        self, timeframe: TimeFrameLiteral, delta: Union[float, int]
-    ) -> str:
+    def _format_timeframe(self, timeframe: TimeFrameLiteral, delta: int) -> str:
         form = self.timeframes[timeframe]
         delta = abs(delta)
         if isinstance(form, Mapping):
@@ -2671,9 +2665,7 @@ class MoroccoArabicLocale(ArabicLocale):
 
 
 class IcelandicLocale(Locale):
-    def _format_timeframe(
-        self, timeframe: TimeFrameLiteral, delta: Union[float, int]
-    ) -> str:
+    def _format_timeframe(self, timeframe: TimeFrameLiteral, delta: int) -> str:
         form = self.timeframes[timeframe]
         if delta < 0:
             form = form[0]
@@ -3030,9 +3022,7 @@ class CzechLocale(Locale):
     ]
     day_abbreviations = ["", "po", "út", "st", "čt", "pá", "so", "ne"]
 
-    def _format_timeframe(
-        self, timeframe: TimeFrameLiteral, delta: Union[float, int]
-    ) -> str:
+    def _format_timeframe(self, timeframe: TimeFrameLiteral, delta: int) -> str:
         """Czech aware time frame format function, takes into account
         the differences between past and future forms."""
         abs_delta = abs(delta)
@@ -3130,9 +3120,7 @@ class SlovakLocale(Locale):
     ]
     day_abbreviations = ["", "po", "ut", "st", "št", "pi", "so", "ne"]
 
-    def _format_timeframe(
-        self, timeframe: TimeFrameLiteral, delta: Union[float, int]
-    ) -> str:
+    def _format_timeframe(self, timeframe: TimeFrameLiteral, delta: int) -> str:
         """Slovak aware time frame format function, takes into account
         the differences between past and future forms."""
         abs_delta = abs(delta)
@@ -3306,9 +3294,7 @@ class HebrewLocale(Locale):
     day_names = ["", "שני", "שלישי", "רביעי", "חמישי", "שישי", "שבת", "ראשון"]
     day_abbreviations = ["", "ב׳", "ג׳", "ד׳", "ה׳", "ו׳", "ש׳", "א׳"]
 
-    def _format_timeframe(
-        self, timeframe: TimeFrameLiteral, delta: Union[float, int]
-    ) -> str:
+    def _format_timeframe(self, timeframe: TimeFrameLiteral, delta: int) -> str:
         """Hebrew couple of <timeframe> aware"""
         couple = f"2-{timeframe}"
         single = timeframe.rstrip("s")
@@ -3627,9 +3613,7 @@ class HungarianLocale(Locale):
 
     meridians = {"am": "de", "pm": "du", "AM": "DE", "PM": "DU"}
 
-    def _format_timeframe(
-        self, timeframe: TimeFrameLiteral, delta: Union[float, int]
-    ) -> str:
+    def _format_timeframe(self, timeframe: TimeFrameLiteral, delta: int) -> str:
         form = self.timeframes[timeframe]
 
         if isinstance(form, Mapping):
@@ -4294,9 +4278,7 @@ class EstonianLocale(Locale):
     ]
     day_abbreviations = ["", "Esm", "Teis", "Kolm", "Nelj", "Re", "Lau", "Püh"]
 
-    def _format_timeframe(
-        self, timeframe: TimeFrameLiteral, delta: Union[float, int]
-    ) -> str:
+    def _format_timeframe(self, timeframe: TimeFrameLiteral, delta: int) -> str:
         form = self.timeframes[timeframe]
         if delta > 0:
             _form = form["future"]
@@ -4551,9 +4533,7 @@ class CroatianLocale(Locale):
         "ne",
     ]
 
-    def _format_timeframe(
-        self, timeframe: TimeFrameLiteral, delta: Union[float, int]
-    ) -> str:
+    def _format_timeframe(self, timeframe: TimeFrameLiteral, delta: int) -> str:
         form = self.timeframes[timeframe]
         delta = abs(delta)
         if isinstance(form, Mapping):
@@ -4888,9 +4868,7 @@ class MalteseLocale(Locale):
         "Ħ",
     ]
 
-    def _format_timeframe(
-        self, timeframe: TimeFrameLiteral, delta: Union[float, int]
-    ) -> str:
+    def _format_timeframe(self, timeframe: TimeFrameLiteral, delta: int) -> str:
         form = self.timeframes[timeframe]
         delta = abs(delta)
         if isinstance(form, Mapping):
@@ -5153,9 +5131,7 @@ class SerbianLocale(Locale):
         "ne",  # не
     ]
 
-    def _format_timeframe(
-        self, timeframe: TimeFrameLiteral, delta: Union[float, int]
-    ) -> str:
+    def _format_timeframe(self, timeframe: TimeFrameLiteral, delta: int) -> str:
         form = self.timeframes[timeframe]
         delta = abs(delta)
         if isinstance(form, Mapping):


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [ ] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [x] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

Changed type annotation for delta argument of `_format_timeframe` from `Union[float, int]` to `int` since we expect a truncated value as described in https://github.com/arrow-py/arrow/pull/986.

I also bumped `mypy` and other pre-commit dependencies.

<!--
Replace this commented text block with a description of your code changes.

If your PR has an associated issue, insert the issue number (e.g. #703) or directly link to the GitHub issue (e.g. https://github.com/arrow-py/arrow/issues/703).

Pro-tip: writing "Closes: #703" in the PR body will automatically close issue #703 when the PR is merged.
-->
