### PR TITLE
Added Error Checking For Empty Granularity List

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -1258,6 +1258,13 @@ class Arrow:
                 return locale.describe(granularity, delta, only_distance=only_distance)
 
             else:
+
+                if not granularity:
+                    raise ValueError(
+                        "Empty granularity list provided. "
+                        "Please select between 'second', 'minute', 'hour', 'day', 'week', 'month' or 'year'."
+                    )
+
                 timeframes: List[Tuple[TimeFrameLiteral, float]] = []
 
                 def gather_timeframes(_delta: float, _frame: TimeFrameLiteral) -> float:

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -2266,6 +2266,13 @@ class TestArrowHumanize:
         with pytest.raises(ValueError):
             arw.humanize(later, granularity="week")
 
+    def test_empty_granularity_list(self):
+        arw = arrow.Arrow(2013, 1, 1, 0, 0, 0)
+        later = arw.shift(seconds=55000)
+
+        with pytest.raises(ValueError):
+            arw.humanize(later, granularity=[])
+
     # Bulgarian is an example of a language that overrides _format_timeframe
     # Applicabale to all locales. Note: Contributors need to make sure
     # that if they override describe or describe_mutli, that delta


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [ ] 🧪  Added **tests** for changed code.
- [ ] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [ ] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [ ] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

Closes #1015. Added a basic error check to make sure empty granularity list raises a Value Error. 

<!--
Replace this commented text block with a description of your code changes.

If your PR has an associated issue, insert the issue number (e.g. #703) or directly link to the GitHub issue (e.g. https://github.com/arrow-py/arrow/issues/703).

Pro-tip: writing "Closes: #703" in the PR body will automatically close issue #703 when the PR is merged.
-->
