### PR TITLE
Add an "all" granularity to humanize

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -69,6 +69,7 @@ _BOUNDS = Literal["[)", "()", "(]", "[]"]
 
 _GRANULARITY = Literal[
     "auto",
+    "all",
     "second",
     "minute",
     "hour",
@@ -1130,7 +1131,8 @@ class Arrow:
         :param locale: (optional) a ``str`` specifying a locale.  Defaults to 'en-us'.
         :param only_distance: (optional) returns only time difference eg: "11 seconds" without "in" or "ago" part.
         :param granularity: (optional) defines the precision of the output. Set it to strings 'second', 'minute',
-                           'hour', 'day', 'week', 'month' or 'year' or a list of any combination of these strings
+                           'hour', 'day', 'week', 'month' or 'year' or a list of any combination of these strings.
+                           Set it to 'all' to include all possible units in the granularity.
 
         Usage::
 
@@ -1228,7 +1230,7 @@ class Arrow:
                     years = sign * max(delta_second // self._SECS_PER_YEAR, 2)
                     return locale.describe("years", years, only_distance=only_distance)
 
-            elif isinstance(granularity, str):
+            elif isinstance(granularity, str) and granularity != "all":
                 granularity = cast(TimeFrameLiteral, granularity)  # type: ignore[assignment]
 
                 if granularity == "second":
@@ -1282,6 +1284,10 @@ class Arrow:
                     "minute",
                     "second",
                 )
+
+                if granularity == "all":
+                    granularity = cast(List[_GRANULARITY], frames)
+
                 for frame in frames:
                     delta = gather_timeframes(delta, frame)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -242,6 +242,8 @@ Indicate a specific time granularity (or multiple):
     'an hour and 6 minutes ago'
     >>> future.humanize(present, only_distance=True, granularity=["hour", "minute"])
     'an hour and 6 minutes'
+    >>> future.humanize(present, granularity="all")
+    'in 0 years 0 months 0 weeks 0 days an hour 6 minutes and 0 seconds'
 
 Support for a growing number of locales (see ``locales.py`` for supported languages):
 

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -2032,6 +2032,49 @@ class TestArrowHumanize:
             == "a minute and 2 seconds ago"
         )
 
+    def test_all_granularity(self):
+        assert (
+            self.now.humanize(granularity="all")
+            == "in 0 years 0 months 0 weeks 0 days 0 hours 0 minutes and 0 seconds"
+        )  # TODO: this should be "ago"; change this when #997 is merged
+
+        later105 = self.now.shift(seconds=10 ** 5)
+        assert (
+            self.now.humanize(later105, granularity="all")
+            == "0 years 0 months 0 weeks a day 3 hours 46 minutes and 40 seconds ago"
+        )
+        assert (
+            later105.humanize(self.now, granularity="all")
+            == "in 0 years 0 months 0 weeks a day 3 hours 46 minutes and 40 seconds"
+        )
+
+        later108 = self.now.shift(seconds=10 ** 8)
+        assert (
+            self.now.humanize(later108, granularity="all")
+            == "3 years 2 months 0 weeks a day 9 hours 46 minutes and 40 seconds ago"
+        )
+        assert (
+            later108.humanize(self.now, granularity="all")
+            == "in 3 years 2 months 0 weeks a day 9 hours 46 minutes and 40 seconds"
+        )
+        assert (
+            self.now.humanize(later108, granularity="all", only_distance=True)
+            == "3 years 2 months 0 weeks a day 9 hours 46 minutes and 40 seconds"
+        )
+
+        later_two_months = self.now.shift(months=2)
+        assert (
+            self.now.humanize(later_two_months, granularity="all")
+            == "in 0 years 2 months 0 weeks 0 days 0 hours 0 minutes and 0 seconds"
+        )  # TODO: this should be "ago"; change this when #997 is merged
+        assert (
+            later_two_months.humanize(self.now, granularity="all")
+            == "in 0 years 2 months 0 weeks 0 days 0 hours 0 minutes and 0 seconds"
+        )
+
+        with pytest.raises(ValueError):
+            self.now.humanize(later108, granularity=["all", "year"])
+
     def test_seconds(self):
 
         later = self.now.shift(seconds=10)


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [x] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [x] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

Add an "all" granularity to the humanize function. When specified, it internally sets all possible units for the granularity (years, months, weeks, days, hours, minutes, and seconds). This granularity is mutually exclusive with the other granularities; it's not valid to specify it in a list of granularities.

The motivation is that it's more convenient to specify a single string than a list of 7 strings. It will make more sense to use full precision once #997 is merged. Speaking of which, some newly added tests will have to be fixed once #997 is merged and the `describe_multi` bug is fixed.

Resolve #1014 