### PR TITLE
Refactored Arabic Locale For Dehumanize Support

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -2546,17 +2546,17 @@ class ArabicLocale(Locale):
     timeframes: ClassVar[Mapping[TimeFrameLiteral, Union[str, Mapping[str, str]]]] = {
         "now": "الآن",
         "second": "ثانية",
-        "seconds": {"double": "ثانيتين", "ten": "{0} ثوان", "higher": "{0} ثانية"},
+        "seconds": {"2": "ثانيتين", "ten": "{0} ثوان", "higher": "{0} ثانية"},
         "minute": "دقيقة",
-        "minutes": {"double": "دقيقتين", "ten": "{0} دقائق", "higher": "{0} دقيقة"},
+        "minutes": {"2": "دقيقتين", "ten": "{0} دقائق", "higher": "{0} دقيقة"},
         "hour": "ساعة",
-        "hours": {"double": "ساعتين", "ten": "{0} ساعات", "higher": "{0} ساعة"},
+        "hours": {"2": "ساعتين", "ten": "{0} ساعات", "higher": "{0} ساعة"},
         "day": "يوم",
-        "days": {"double": "يومين", "ten": "{0} أيام", "higher": "{0} يوم"},
+        "days": {"2": "يومين", "ten": "{0} أيام", "higher": "{0} يوم"},
         "month": "شهر",
-        "months": {"double": "شهرين", "ten": "{0} أشهر", "higher": "{0} شهر"},
+        "months": {"2": "شهرين", "ten": "{0} أشهر", "higher": "{0} شهر"},
         "year": "سنة",
-        "years": {"double": "سنتين", "ten": "{0} سنوات", "higher": "{0} سنة"},
+        "years": {"2": "سنتين", "ten": "{0} سنوات", "higher": "{0} سنة"},
     }
 
     month_names = [
@@ -2607,7 +2607,7 @@ class ArabicLocale(Locale):
         delta = abs(delta)
         if isinstance(form, Mapping):
             if delta == 2:
-                form = form["double"]
+                form = form["2"]
             elif 2 < delta <= 10:
                 form = form["ten"]
             else:


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [ ] 🧪  Added **tests** for changed code.
- [ ] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [ ] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [ ] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

<!--
Replace this commented text block with a description of your code changes.

If your PR has an associated issue, insert the issue number (e.g. #703) or directly link to the GitHub issue (e.g. https://github.com/arrow-py/arrow/issues/703).

Pro-tip: writing "Closes: #703" in the PR body will automatically close issue #703 when the PR is merged.
-->

Refactor of Arabic Locale for future dehumanize support. The main reason for this change is that we need a way to convey the actual delta some of those strings represent. Rather than creating a look-up table, or some kind of translation logic, I think it is easier to just have the key be the string representation of an integer. This way, dehumanize call easily interpret this. This will make more sense, when I push the actual dehumanize update PR (after the backlog of locale refactor PRs get merged in :) ). 