### PR TITLE
Default to UTC for arrow.fromtimestamp()

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -246,12 +246,12 @@ class Arrow:
         the given timezone.
 
         :param timestamp: an ``int`` or ``float`` timestamp, or a ``str`` that converts to either.
-        :param tzinfo: (optional) a ``tzinfo`` object.  Defaults to local time.
+        :param tzinfo: (optional) a ``tzinfo`` object.  Defaults to UTC time.
 
         """
 
         if tzinfo is None:
-            tzinfo = dateutil_tz.tzlocal()
+            tzinfo = dateutil_tz.tzutc()
         elif isinstance(tzinfo, str):
             tzinfo = parser.TzinfoParser.parse(tzinfo)
 

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -102,11 +102,10 @@ class TestTestArrowFactory:
 
     def test_fromtimestamp(self):
 
-        timestamp = time.time()
-
-        result = arrow.Arrow.fromtimestamp(timestamp)
+        timestamp = datetime.utcnow().timestamp()
+        result = arrow.Arrow.fromtimestamp(timestamp, tzinfo=tz.tzutc())
         assert_datetime_equality(
-            result._datetime, datetime.now().replace(tzinfo=tz.tzlocal())
+            result._datetime, datetime.fromtimestamp(timestamp, tz=tz.tzutc())
         )
 
         result = arrow.Arrow.fromtimestamp(timestamp, tzinfo=tz.gettz("Europe/Paris"))


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [x] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [x] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

Default to UTC for arrow.fromtimestamp()
