### PR TITLE
Revert "Default to UTC for arrow.fromtimestamp()"

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -246,12 +246,12 @@ class Arrow:
         the given timezone.
 
         :param timestamp: an ``int`` or ``float`` timestamp, or a ``str`` that converts to either.
-        :param tzinfo: (optional) a ``tzinfo`` object.  Defaults to UTC time.
+        :param tzinfo: (optional) a ``tzinfo`` object.  Defaults to local time.
 
         """
 
         if tzinfo is None:
-            tzinfo = dateutil_tz.tzutc()
+            tzinfo = dateutil_tz.tzlocal()
         elif isinstance(tzinfo, str):
             tzinfo = parser.TzinfoParser.parse(tzinfo)
 

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -102,10 +102,11 @@ class TestTestArrowFactory:
 
     def test_fromtimestamp(self):
 
-        timestamp = datetime.utcnow().timestamp()
-        result = arrow.Arrow.fromtimestamp(timestamp, tzinfo=tz.tzutc())
+        timestamp = time.time()
+
+        result = arrow.Arrow.fromtimestamp(timestamp)
         assert_datetime_equality(
-            result._datetime, datetime.fromtimestamp(timestamp, tz=tz.tzutc())
+            result._datetime, datetime.now().replace(tzinfo=tz.tzlocal())
         )
 
         result = arrow.Arrow.fromtimestamp(timestamp, tzinfo=tz.gettz("Europe/Paris"))


### PR DESCRIPTION
Reverts arrow-py/arrow#1036