### PR TITLE
Revert dateutil lock back to >= 2.7.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-1.2.0 (2021-09-06)
+1.2.0 (2021-09-12)
 ------------------
 
 - [NEW] Added Albanian, Tamil and Zulu locales.
@@ -9,7 +9,6 @@ Changelog
 - [FIX] The Estonian, Finnish, Nepali and Zulu locales now support ``dehumanize``.
 - [FIX] Improved validation checks when using parser tokens ``A`` and ``hh``.
 - [FIX] Minor bug fixes to Catalan, Cantonese, Greek and Nepali locales.
-- [INTERNAL] Updated ``dateutil`` requirement in ``setup.py`` to ``>=2.8.2``.
 
 1.1.1 (2021-06-24)
 ------------------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ pre-commit==2.*
 pytest==6.*
 pytest-cov==2.*
 pytest-mock==3.*
-python-dateutil>=2.8.2
+python-dateutil>=2.7.0
 pytz==2021.*
 simplejson==3.*
 sphinx==4.*

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     zip_safe=False,
     python_requires=">=3.6",
     install_requires=[
-        "python-dateutil>=2.8.2",
+        "python-dateutil>=2.7.0",
         "typing_extensions; python_version<'3.8'",
     ],
     classifiers=[


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [ ] 🧪  Added **tests** for changed code.
- [ ] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [ ] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [x] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes
Revert dateutil lock back to `>=2.7.0` based on feedback from @pganssle in https://github.com/arrow-py/arrow/pull/1006/files
<!--
Replace this commented text block with a description of your code changes.

If your PR has an associated issue, insert the issue number (e.g. #703) or directly link to the GitHub issue (e.g. https://github.com/arrow-py/arrow/issues/703).

Pro-tip: writing "Closes: #703" in the PR body will automatically close issue #703 when the PR is merged.
-->
