### PR TITLE
add Sinhala locale

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -5642,3 +5642,167 @@ class AlbanianLocale(Locale):
         "sht",
         "die",
     ]
+
+
+class SinhalaLocale(Locale):
+
+    names = ["si", "si-lk"]
+
+    past = "{0}ට පෙර"
+    future = "{0}"
+    and_word = "සහ"
+
+    timeframes: ClassVar[Mapping[TimeFrameLiteral, Union[Mapping[str, str], str]]] = {
+        "now": "දැන්",
+        "second": {
+            "past": "තත්පරයක",
+            "future": "තත්පරයකින්",
+        },  # ක් is the article
+        "seconds": {
+            "past": "තත්පර {0} ක",
+            "future": "තත්පර {0} කින්",
+        },
+        "minute": {
+            "past": "විනාඩියක",
+            "future": "විනාඩියකින්",
+        },
+        "minutes": {
+            "past": "විනාඩි {0} ක",
+            "future": "මිනිත්තු {0} කින්",
+        },
+        "hour": {"past": "පැයක", "future": "පැයකින්"},
+        "hours": {
+            "past": "පැය {0} ක",
+            "future": "පැය {0} කින්",
+        },
+        "day": {"past": "දිනක", "future": "දිනකට"},
+        "days": {
+            "past": "දින {0} ක",
+            "future": "දින {0} කින්",
+        },
+        "week": {"past": "සතියක", "future": "සතියකින්"},
+        "weeks": {
+            "past": "සති {0} ක",
+            "future": "සති {0} කින්",
+        },
+        "month": {"past": "මාසයක", "future": "එය මාසය තුළ"},
+        "months": {
+            "past": "මාස {0} ක",
+            "future": "මාස {0} කින්",
+        },
+        "year": {"past": "වසරක", "future": "වසරක් තුළ"},
+        "years": {
+            "past": "අවුරුදු {0} ක",
+            "future": "අවුරුදු {0} තුළ",
+        },
+    }
+    # Sinhala: the general format to describe timeframe is different from past and future,
+    # so we do not copy the original timeframes dictionary
+    timeframes_only_distance = dict()
+    timeframes_only_distance["second"] = "තත්පරයක්"
+    timeframes_only_distance["seconds"] = "තත්පර {0}"
+    timeframes_only_distance["minute"] = "මිනිත්තුවක්"
+    timeframes_only_distance["minutes"] = "විනාඩි {0}"
+    timeframes_only_distance["hour"] = "පැයක්"
+    timeframes_only_distance["hours"] = "පැය {0}"
+    timeframes_only_distance["day"] = "දවසක්"
+    timeframes_only_distance["days"] = "දවස් {0}"
+    timeframes_only_distance["week"] = "සතියක්"
+    timeframes_only_distance["weeks"] = "සති {0}"
+    timeframes_only_distance["month"] = "මාසයක්"
+    timeframes_only_distance["months"] = "මාස {0}"
+    timeframes_only_distance["year"] = "අවුරුද්දක්"
+    timeframes_only_distance["years"] = "අවුරුදු {0}"
+
+    def _format_timeframe(self, timeframe: TimeFrameLiteral, delta: int) -> str:
+        """
+        Sinhala awares time frame format function, takes into account
+        the differences between general, past, and future forms (three different suffixes).
+        """
+        abs_delta = abs(delta)
+        form = self.timeframes[timeframe]
+
+        if isinstance(form, str):
+            return form.format(abs_delta)
+
+        if delta > 0:
+            key = "future"
+        else:
+            key = "past"
+        form = form[key]
+
+        return form.format(abs_delta)
+
+    def describe(
+        self,
+        timeframe: TimeFrameLiteral,
+        delta: Union[float, int] = 1,  # key is always future when only_distance=False
+        only_distance: bool = False,
+    ) -> str:
+        """Describes a delta within a timeframe in plain language.
+
+        :param timeframe: a string representing a timeframe.
+        :param delta: a quantity representing a delta in a timeframe.
+        :param only_distance: return only distance eg: "11 seconds" without "in" or "ago" keywords
+        """
+
+        if not only_distance:
+            return super().describe(timeframe, delta, only_distance)
+        # Sinhala uses a different case without 'in' or 'ago'
+        humanized = self.timeframes_only_distance[timeframe].format(trunc(abs(delta)))
+
+        return humanized
+
+    month_names = [
+        "",
+        "ජනවාරි",
+        "පෙබරවාරි",
+        "මාර්තු",
+        "අප්‍රේල්",
+        "මැයි",
+        "ජූනි",
+        "ජූලි",
+        "අගෝස්තු",
+        "සැප්තැම්බර්",
+        "ඔක්තෝබර්",
+        "නොවැම්බර්",
+        "දෙසැම්බර්",
+    ]
+
+    month_abbreviations = [
+        "",
+        "ජන",
+        "පෙබ",
+        "මාර්",
+        "අප්‍රේ",
+        "මැයි",
+        "ජුනි",
+        "ජූලි",
+        "අගෝ",
+        "සැප්",
+        "ඔක්",
+        "නොවැ",
+        "දෙසැ",
+    ]
+
+    day_names = [
+        "",
+        "සදුදා",
+        "අඟහරැවදා",
+        "බදාදා",
+        "බ්‍රහස්‍පතින්‍දා",
+        "සිකුරාදා",
+        "සෙනසුරාදා",
+        "ඉරිදා",
+    ]
+
+    day_abbreviations = [
+        "",
+        "සදුද",
+        "බදා",
+        "බදා",
+        "සිකු",
+        "සෙන",
+        "අ",
+        "ඉරිදා",
+    ]

--- a/tests/test_locales.py
+++ b/tests/test_locales.py
@@ -1922,3 +1922,77 @@ class TestTamilLocale:
         dt = arrow.Arrow(2015, 4, 11, 17, 30, 00)
         assert self.locale.day_name(dt.isoweekday()) == "சனிக்கிழமை"
         assert self.locale.day_abbreviation(dt.isoweekday()) == "சனி"
+
+
+@pytest.mark.usefixtures("lang_locale")
+class TestSinhalaLocale:
+    def test_format_timeframe(self):
+        assert self.locale._format_timeframe("now", 0) == "දැන්"
+        assert self.locale._format_timeframe("second", -1) == "තත්පරයක"
+        assert self.locale._format_timeframe("second", 1) == "තත්පරයකින්"
+        assert self.locale._format_timeframe("seconds", -30) == "තත්පර 30 ක"
+
+        assert self.locale._format_timeframe("minute", -1) == "විනාඩියක"
+        assert self.locale._format_timeframe("minutes", 4) == "මිනිත්තු 4 කින්"
+
+        assert self.locale._format_timeframe("hour", -1) == "පැයක"
+        assert self.locale._format_timeframe("hours", 23) == "පැය 23 කින්"
+
+        assert self.locale._format_timeframe("day", 1) == "දිනකට"
+        assert self.locale._format_timeframe("days", -12) == "දින 12 ක"
+
+        assert self.locale._format_timeframe("week", -1) == "සතියක"
+        assert self.locale._format_timeframe("weeks", -10) == "සති 10 ක"
+
+        assert self.locale._format_timeframe("month", -1) == "මාසයක"
+        assert self.locale._format_timeframe("months", -2) == "මාස 2 ක"
+
+        assert self.locale._format_timeframe("year", 1) == "වසරක් තුළ"
+        assert self.locale._format_timeframe("years", -21) == "අවුරුදු 21 ක"
+
+    def test_describe_si(self):
+        assert self.locale.describe("second", only_distance=True) == "තත්පරයක්"
+        assert (
+            self.locale.describe("second", only_distance=False) == "තත්පරයකින්"
+        )  # (in) a second
+
+        assert self.locale.describe("minute", only_distance=True) == "මිනිත්තුවක්"
+        assert (
+            self.locale.describe("minute", only_distance=False) == "විනාඩියකින්"
+        )  # (in) a minute
+
+        assert self.locale.describe("hour", only_distance=True) == "පැයක්"
+        assert self.locale.describe("hour", only_distance=False) == "පැයකින්"
+
+        assert self.locale.describe("day", only_distance=True) == "දවසක්"
+        assert self.locale.describe("day", only_distance=False) == "දිනකට"
+
+        assert self.locale.describe("week", only_distance=True) == "සතියක්"
+        assert self.locale.describe("week", only_distance=False) == "සතියකින්"
+
+        assert self.locale.describe("month", only_distance=True) == "මාසයක්"
+        assert self.locale.describe("month", only_distance=False) == "එය මාසය තුළ"
+
+        assert self.locale.describe("year", only_distance=True) == "අවුරුද්දක්"
+        assert self.locale.describe("year", only_distance=False) == "වසරක් තුළ"
+
+    def test_format_relative_now(self):
+        result = self.locale._format_relative("දැන්", "now", 0)
+        assert result == "දැන්"
+
+    def test_format_relative_future(self):
+
+        result = self.locale._format_relative("පැයකින්", "පැය", 1)
+
+        assert result == "පැයකින්"  # (in) one hour
+
+    def test_format_relative_past(self):
+
+        result = self.locale._format_relative("පැයක", "පැය", -1)
+
+        assert result == "පැයකට පෙර"  # an hour ago
+
+    def test_weekday(self):
+        dt = arrow.Arrow(2015, 4, 11, 17, 30, 00)
+        assert self.locale.day_name(dt.isoweekday()) == "සෙනසුරාදා"
+        assert self.locale.day_abbreviation(dt.isoweekday()) == "අ"


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [x] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

Add Sinhala locale. Sinhala awares time frame format and describe function, takes into account the differences between general, past, and future forms (three different suffixes). So we do not copy the original timeframes dictionary as `timeframes_only_distance`, we wrote a new `timeframes_only_distance` dictionary :) 
