### PR TITLE
Fix pypy CI issues and begin testing against Python 3.10

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -16,12 +16,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3", "3.6", "3.7", "3.8", "3.9"]
+        python-version: ["pypy-3.7", "3.6", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
           # pypy3 randomly fails on Windows builds
           - os: windows-latest
-            python-version: "pypy3"
+            python-version: "pypy-3.7"
 
     steps:
       # Check out latest code

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.7", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["pypy-3.7", "3.6", "3.7", "3.8", "3.9", "3.10-dev"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
           # pypy3 randomly fails on Windows builds

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ pytest==6.*
 pytest-cov==2.*
 pytest-mock==3.*
 python-dateutil>=2.7.0
-pytz==2021.*
+pytz==2021.1
 simplejson==3.*
 sphinx==4.*
 sphinx-autodoc-typehints==1.*

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,16 @@
 [tox]
 minversion = 3.18.0
-envlist = py{py3,36,37,38,39}
+envlist = py{py3,36,37,38,39,310}
 skip_missing_interpreters = true
 
 [gh-actions]
 python =
-    pypy3: pypy3
+    pypy-3.7: pypy3
     3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [ ] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

<!--
Replace this commented text block with a description of your code changes.

If your PR has an associated issue, insert the issue number (e.g. #703) or directly link to the GitHub issue (e.g. https://github.com/arrow-py/arrow/issues/703).

Pro-tip: writing "Closes: #703" in the PR body will automatically close issue #703 when the PR is merged.
-->
Pypy3 builds recently began failing on our macOS CI runners. Turns out that this is because macOS 11 runners beginning to be used and they lack support for pypy3.6. I needed to update our workflow YAML to manually invoke pypy3.7 to fix this issue.

While I was at it, I also added support for testing against python 3.10 since it is in the final RC stages and will be released very soon.