### PR TITLE
chore: align format of cn-zh timeframe

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -951,7 +951,7 @@ class ChineseCNLocale(Locale):
 
     timeframes = {
         "now": "刚才",
-        "second": "一秒",
+        "second": "1秒",
         "seconds": "{0}秒",
         "minute": "1分钟",
         "minutes": "{0}分钟",

--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -959,7 +959,7 @@ class ChineseCNLocale(Locale):
         "hours": "{0}小时",
         "day": "1天",
         "days": "{0}天",
-        "week": "一周",
+        "week": "1周",
         "weeks": "{0}周",
         "month": "1个月",
         "months": "{0}个月",

--- a/tests/test_locales.py
+++ b/tests/test_locales.py
@@ -1674,7 +1674,7 @@ class TestChineseTWLocale:
 class TestChineseCNLocale:
     def test_format_timeframe(self):
         assert self.locale._format_timeframe("now", 0) == "刚才"
-        assert self.locale._format_timeframe("second", 1) == "一秒"
+        assert self.locale._format_timeframe("second", 1) == "1秒"
         assert self.locale._format_timeframe("seconds", 30) == "30秒"
         assert self.locale._format_timeframe("minute", 1) == "1分钟"
         assert self.locale._format_timeframe("minutes", 40) == "40分钟"
@@ -1682,7 +1682,7 @@ class TestChineseCNLocale:
         assert self.locale._format_timeframe("hours", 23) == "23小时"
         assert self.locale._format_timeframe("day", 1) == "1天"
         assert self.locale._format_timeframe("days", 12) == "12天"
-        assert self.locale._format_timeframe("week", 1) == "一周"
+        assert self.locale._format_timeframe("week", 1) == "1周"
         assert self.locale._format_timeframe("weeks", 38) == "38周"
         assert self.locale._format_timeframe("month", 1) == "1个月"
         assert self.locale._format_timeframe("months", 11) == "11个月"


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [x] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

<!--
Replace this commented text block with a description of your code changes.

If your PR has an associated issue, insert the issue number (e.g. #703) or directly link to the GitHub issue (e.g. https://github.com/arrow-py/arrow/issues/703).

Pro-tip: writing "Closes: #703" in the PR body will automatically close issue #703 when the PR is merged.
-->

Use Arabic instead of Chinese in `zh-cn` to present numbers for `second` and `week`, to stay the same with other time period and also `zh-tw` and `zh-hk`
