### PR TITLE
Add support for quarter granularity in Russian (#1062)

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -1515,6 +1515,12 @@ class RussianLocale(SlavicBaseLocale):
             "dual": "{0} месяца",
             "plural": "{0} месяцев",
         },
+        "quarter": "квартал",
+        "quarters": {
+            "singular": "{0} квартал",
+            "dual": "{0} квартала",
+            "plural": "{0} кварталов",
+        },
         "year": "год",
         "years": {"singular": "{0} год", "dual": "{0} года", "plural": "{0} лет"},
     }

--- a/tests/test_locales.py
+++ b/tests/test_locales.py
@@ -260,6 +260,13 @@ class TestRussianLocale:
         result = self.locale._format_timeframe("second", -1)
         assert result == "секунда"
 
+        # Quarter
+        result = self.locale._format_timeframe("quarter", 1)
+        assert result == "квартал"
+
+        result = self.locale._format_timeframe("quarter", -1)
+        assert result == "квартал"
+
     def test_singles_relative(self):
         # Second in the future
         result = self.locale._format_relative("секунду", "second", 1)
@@ -268,6 +275,14 @@ class TestRussianLocale:
         # Second in the past
         result = self.locale._format_relative("секунду", "second", -1)
         assert result == "секунду назад"
+
+        # Quarter in the future
+        result = self.locale._format_relative("квартал", "quarter", 1)
+        assert result == "через квартал"
+
+        # Quarter in the past
+        result = self.locale._format_relative("квартал", "quarter", -1)
+        assert result == "квартал назад"
 
     def test_plurals_timeframe(self):
         # Seconds in the future
@@ -302,6 +317,38 @@ class TestRussianLocale:
         result = self.locale._format_timeframe("seconds", -25)
         assert result == "25 секунд"
 
+        # Quarters in the future
+        result = self.locale._format_timeframe("quarters", 2)
+        assert result == "2 квартала"
+
+        result = self.locale._format_timeframe("quarters", 5)
+        assert result == "5 кварталов"
+
+        result = self.locale._format_timeframe("quarters", 21)
+        assert result == "21 квартал"
+
+        result = self.locale._format_timeframe("quarters", 22)
+        assert result == "22 квартала"
+
+        result = self.locale._format_timeframe("quarters", 25)
+        assert result == "25 кварталов"
+
+        # Quarters in the past
+        result = self.locale._format_timeframe("quarters", -2)
+        assert result == "2 квартала"
+
+        result = self.locale._format_timeframe("quarters", -5)
+        assert result == "5 кварталов"
+
+        result = self.locale._format_timeframe("quarters", -21)
+        assert result == "21 квартал"
+
+        result = self.locale._format_timeframe("quarters", -22)
+        assert result == "22 квартала"
+
+        result = self.locale._format_timeframe("quarters", -25)
+        assert result == "25 кварталов"
+
     def test_plurals_relative(self):
         # Seconds in the future
         result = self.locale._format_relative("1 секунду", "seconds", 1)
@@ -334,6 +381,38 @@ class TestRussianLocale:
 
         result = self.locale._format_relative("25 секунд", "seconds", -25)
         assert result == "25 секунд назад"
+
+        # Quarters in the future
+        result = self.locale._format_relative("1 квартал", "quarters", 1)
+        assert result == "через 1 квартал"
+
+        result = self.locale._format_relative("2 квартала", "quarters", 2)
+        assert result == "через 2 квартала"
+
+        result = self.locale._format_relative("5 кварталов", "quarters", 5)
+        assert result == "через 5 кварталов"
+
+        result = self.locale._format_relative("21 квартал", "quarters", 21)
+        assert result == "через 21 квартал"
+
+        result = self.locale._format_relative("25 кварталов", "quarters", 25)
+        assert result == "через 25 кварталов"
+
+        # Quarters in the past
+        result = self.locale._format_relative("1 квартал", "quarters", -1)
+        assert result == "1 квартал назад"
+
+        result = self.locale._format_relative("2 квартала", "quarters", -2)
+        assert result == "2 квартала назад"
+
+        result = self.locale._format_relative("5 кварталов", "quarters", -5)
+        assert result == "5 кварталов назад"
+
+        result = self.locale._format_relative("21 квартал", "quarters", -21)
+        assert result == "21 квартал назад"
+
+        result = self.locale._format_relative("25 кварталов", "quarters", -25)
+        assert result == "25 кварталов назад"
 
     def test_plurals2(self):
         assert self.locale._format_timeframe("hours", 0) == "0 часов"


### PR DESCRIPTION
## Pull Request Checklist

- [x] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

## Description of Changes

Fix for issue #1062
Closes: #1062