### PR TITLE
Adding brief parameter to humanize

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -1125,6 +1125,7 @@ class Arrow:
         locale: str = DEFAULT_LOCALE,
         only_distance: bool = False,
         granularity: Union[_GRANULARITY, List[_GRANULARITY]] = "auto",
+        brief: bool = False,
     ) -> str:
         """Returns a localized, humanized representation of a relative difference in time.
 
@@ -1134,6 +1135,7 @@ class Arrow:
         :param only_distance: (optional) returns only time difference eg: "11 seconds" without "in" or "ago" part.
         :param granularity: (optional) defines the precision of the output. Set it to strings 'second', 'minute',
                            'hour', 'day', 'week', 'month' or 'year' or a list of any combination of these strings
+        :param brief: (optional) return shortened form of only the time distance eg: "11s" without "in", "ago", or "seconds"
 
         Usage::
 
@@ -1179,41 +1181,59 @@ class Arrow:
         try:
             if granularity == "auto":
                 if diff < 10:
-                    return locale.describe("now", only_distance=only_distance)
+                    return locale.describe(
+                        "now", only_distance=only_distance, brief=brief
+                    )
 
                 if diff < self._SECS_PER_MINUTE:
                     seconds = sign * delta_second
                     return locale.describe(
-                        "seconds", seconds, only_distance=only_distance
+                        "seconds", seconds, only_distance=only_distance, brief=brief
                     )
 
                 elif diff < self._SECS_PER_MINUTE * 2:
-                    return locale.describe("minute", sign, only_distance=only_distance)
+                    return locale.describe(
+                        "minute", sign, only_distance=only_distance, brief=brief
+                    )
                 elif diff < self._SECS_PER_HOUR:
                     minutes = sign * max(delta_second // self._SECS_PER_MINUTE, 2)
                     return locale.describe(
-                        "minutes", minutes, only_distance=only_distance
+                        "minutes", minutes, only_distance=only_distance, brief=brief
                     )
 
                 elif diff < self._SECS_PER_HOUR * 2:
-                    return locale.describe("hour", sign, only_distance=only_distance)
+                    return locale.describe(
+                        "hour", sign, only_distance=only_distance, brief=brief
+                    )
                 elif diff < self._SECS_PER_DAY:
                     hours = sign * max(delta_second // self._SECS_PER_HOUR, 2)
-                    return locale.describe("hours", hours, only_distance=only_distance)
+                    return locale.describe(
+                        "hours", hours, only_distance=only_distance, brief=brief
+                    )
                 elif diff < self._SECS_PER_DAY * 2:
-                    return locale.describe("day", sign, only_distance=only_distance)
+                    return locale.describe(
+                        "day", sign, only_distance=only_distance, brief=brief
+                    )
                 elif diff < self._SECS_PER_WEEK:
                     days = sign * max(delta_second // self._SECS_PER_DAY, 2)
-                    return locale.describe("days", days, only_distance=only_distance)
+                    return locale.describe(
+                        "days", days, only_distance=only_distance, brief=brief
+                    )
 
                 elif diff < self._SECS_PER_WEEK * 2:
-                    return locale.describe("week", sign, only_distance=only_distance)
+                    return locale.describe(
+                        "week", sign, only_distance=only_distance, brief=brief
+                    )
                 elif diff < self._SECS_PER_MONTH:
                     weeks = sign * max(delta_second // self._SECS_PER_WEEK, 2)
-                    return locale.describe("weeks", weeks, only_distance=only_distance)
+                    return locale.describe(
+                        "weeks", weeks, only_distance=only_distance, brief=brief
+                    )
 
                 elif diff < self._SECS_PER_MONTH * 2:
-                    return locale.describe("month", sign, only_distance=only_distance)
+                    return locale.describe(
+                        "month", sign, only_distance=only_distance, brief=brief
+                    )
                 elif diff < self._SECS_PER_YEAR:
                     # TODO revisit for humanization during leap years
                     self_months = self._datetime.year * 12 + self._datetime.month
@@ -1222,14 +1242,18 @@ class Arrow:
                     months = sign * max(abs(other_months - self_months), 2)
 
                     return locale.describe(
-                        "months", months, only_distance=only_distance
+                        "months", months, only_distance=only_distance, brief=brief
                     )
 
                 elif diff < self._SECS_PER_YEAR * 2:
-                    return locale.describe("year", sign, only_distance=only_distance)
+                    return locale.describe(
+                        "year", sign, only_distance=only_distance, brief=brief
+                    )
                 else:
                     years = sign * max(delta_second // self._SECS_PER_YEAR, 2)
-                    return locale.describe("years", years, only_distance=only_distance)
+                    return locale.describe(
+                        "years", years, only_distance=only_distance, brief=brief
+                    )
 
             elif isinstance(granularity, str):
                 granularity = cast(TimeFrameLiteral, granularity)  # type: ignore[assignment]
@@ -1237,7 +1261,9 @@ class Arrow:
                 if granularity == "second":
                     delta = sign * float(delta_second)
                     if abs(delta) < 2:
-                        return locale.describe("now", only_distance=only_distance)
+                        return locale.describe(
+                            "now", only_distance=only_distance, brief=brief
+                        )
                 elif granularity == "minute":
                     delta = sign * delta_second / self._SECS_PER_MINUTE
                 elif granularity == "hour":
@@ -1260,7 +1286,9 @@ class Arrow:
 
                 if trunc(abs(delta)) != 1:
                     granularity += "s"  # type: ignore
-                return locale.describe(granularity, delta, only_distance=only_distance)
+                return locale.describe(
+                    granularity, delta, only_distance=only_distance, brief=brief
+                )
 
             else:
 
@@ -1304,7 +1332,9 @@ class Arrow:
                         "Please select between 'second', 'minute', 'hour', 'day', 'week', 'month', 'quarter' or 'year'."
                     )
 
-                return locale.describe_multi(timeframes, only_distance=only_distance)
+                return locale.describe_multi(
+                    timeframes, only_distance=only_distance, brief=brief
+                )
 
         except KeyError as e:
             raise ValueError(

--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -138,17 +138,22 @@ class Locale:
         timeframe: TimeFrameLiteral,
         delta: Union[float, int] = 0,
         only_distance: bool = False,
+        brief: bool = False,
     ) -> str:
         """Describes a delta within a timeframe in plain language.
 
         :param timeframe: a string representing a timeframe.
         :param delta: a quantity representing a delta in a timeframe.
         :param only_distance: return only distance eg: "11 seconds" without "in" or "ago" keywords
+        :param brief: return shortened string eg: "11s"
         """
 
         humanized = self._format_timeframe(timeframe, trunc(delta))
         if not only_distance:
             humanized = self._format_relative(humanized, timeframe, delta)
+        if brief:
+            humanized = self._format_timeframe(timeframe, trunc(delta))
+            humanized = self._format_brief(humanized)
 
         return humanized
 
@@ -156,23 +161,28 @@ class Locale:
         self,
         timeframes: Sequence[Tuple[TimeFrameLiteral, Union[int, float]]],
         only_distance: bool = False,
+        brief: bool = False,
     ) -> str:
         """Describes a delta within multiple timeframes in plain language.
 
         :param timeframes: a list of string, quantity pairs each representing a timeframe and delta.
         :param only_distance: return only distance eg: "2 hours and 11 seconds" without "in" or "ago" keywords
+        :param brief: returns shortened distance eg: "2h 11s" without and keywords
         """
 
         parts = [
             self._format_timeframe(timeframe, trunc(delta))
             for timeframe, delta in timeframes
         ]
-        if self.and_word:
+        if self.and_word and not brief:
             parts.insert(-1, self.and_word)
         humanized = " ".join(parts)
 
         if not only_distance:
             humanized = self._format_relative(humanized, *timeframes[-1])
+        if brief:
+            parts = [self._format_brief(part) for part in parts]
+            humanized = " ".join(parts)
 
         return humanized
 
@@ -285,6 +295,18 @@ class Locale:
 
         return direction.format(humanized)
 
+    def _format_brief(
+        self,
+        humanized: str,
+    ) -> str:
+
+        parts = humanized.split()
+
+        if parts[0].isnumeric():
+            return parts[0] + parts[1][0]
+
+        return parts[1][0]
+
 
 class EnglishLocale(Locale):
 
@@ -387,15 +409,17 @@ class EnglishLocale(Locale):
         timeframe: TimeFrameLiteral,
         delta: Union[int, float] = 0,
         only_distance: bool = False,
+        brief: bool = False,
     ) -> str:
         """Describes a delta within a timeframe in plain language.
 
         :param timeframe: a string representing a timeframe.
         :param delta: a quantity representing a delta in a timeframe.
         :param only_distance: return only distance eg: "11 seconds" without "in" or "ago" keywords
+        :param brief: return shortened string eg: "11s"
         """
 
-        humanized = super().describe(timeframe, delta, only_distance)
+        humanized = super().describe(timeframe, delta, only_distance, brief)
         if only_distance and timeframe == "now":
             humanized = "instantly"
 
@@ -1982,6 +2006,7 @@ class GermanBaseLocale(Locale):
         timeframe: TimeFrameLiteral,
         delta: Union[int, float] = 0,
         only_distance: bool = False,
+        brief: bool = False,
     ) -> str:
         """Describes a delta within a timeframe in plain language.
 
@@ -3457,6 +3482,7 @@ class HebrewLocale(Locale):
         self,
         timeframes: Sequence[Tuple[TimeFrameLiteral, Union[int, float]]],
         only_distance: bool = False,
+        brief: bool = False,
     ) -> str:
         """Describes a delta within multiple timeframes in plain language.
         In Hebrew, the and word behaves a bit differently.
@@ -5388,6 +5414,7 @@ class LuxembourgishLocale(Locale):
         timeframe: TimeFrameLiteral,
         delta: Union[int, float] = 0,
         only_distance: bool = False,
+        brief: bool = False,
     ) -> str:
 
         if not only_distance:
@@ -5760,6 +5787,7 @@ class SinhalaLocale(Locale):
         timeframe: TimeFrameLiteral,
         delta: Union[float, int] = 1,  # key is always future when only_distance=False
         only_distance: bool = False,
+        brief: bool = False,
     ) -> str:
         """Describes a delta within a timeframe in plain language.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -227,7 +227,6 @@ Indicate time as relative or include only the distance
     >>> future.humanize(present, only_distance=True)
     '2 hours'
 
-
 Indicate a specific time granularity (or multiple):
 
 .. code-block:: python
@@ -242,6 +241,20 @@ Indicate a specific time granularity (or multiple):
     'an hour and 6 minutes ago'
     >>> future.humanize(present, only_distance=True, granularity=["hour", "minute"])
     'an hour and 6 minutes'
+
+Indicate shortened time:
+
+.. code-block:: python
+
+    >>> present = arrow.utcnow()
+    >>> future = present.shift(hours=2)
+    >>> future.humanize(present)
+    'in 2 hours'
+    >>> future.humanize(present, brief=True)
+    '2h'
+    >>> future = present.shift(minutes=66)
+    >>> present.humanize(future, granularity=["hour", "minute"], brief=True)
+    'h 6m'
 
 Support for a growing number of locales (see ``locales.py`` for supported languages):
 

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -2004,6 +2004,10 @@ class TestArrowHumanize:
             == "an hour and 6 minutes"
         )
         assert (
+            later4000.humanize(self.now, granularity=["hour", "minute"], brief=True)
+            == "h 6m"
+        )
+        assert (
             later4000.humanize(self.now, granularity=["day", "hour", "minute"])
             == "in 0 days an hour and 6 minutes"
         )
@@ -2032,6 +2036,15 @@ class TestArrowHumanize:
                 later108onlydistance, only_distance=True, granularity=["month", "week"]
             )
             == "37 months and 4 weeks"
+        )
+        assert (
+            self.now.humanize(
+                later108onlydistance,
+                only_distance=True,
+                granularity=["month", "week"],
+                brief=True,
+            )
+            == "37m 4w"
         )
         # this will change when leap years are implemented
         assert (
@@ -2064,6 +2077,9 @@ class TestArrowHumanize:
         assert self.now.humanize(later, only_distance=True) == "10 seconds"
         assert later.humanize(self.now, only_distance=True) == "10 seconds"
 
+        assert self.now.humanize(later, brief=True) == "10s"
+        assert later.humanize(self.now, brief=True) == "10s"
+
     def test_minute(self):
 
         later = self.now.shift(minutes=1)
@@ -2073,6 +2089,9 @@ class TestArrowHumanize:
 
         assert self.now.humanize(later, only_distance=True) == "a minute"
         assert later.humanize(self.now, only_distance=True) == "a minute"
+
+        assert self.now.humanize(later, brief=True) == "m"
+        assert later.humanize(self.now, brief=True) == "m"
 
     def test_minutes(self):
 
@@ -2084,6 +2103,9 @@ class TestArrowHumanize:
         assert self.now.humanize(later, only_distance=True) == "2 minutes"
         assert later.humanize(self.now, only_distance=True) == "2 minutes"
 
+        assert self.now.humanize(later, brief=True) == "2m"
+        assert later.humanize(self.now, brief=True) == "2m"
+
     def test_hour(self):
 
         later = self.now.shift(hours=1)
@@ -2094,6 +2116,9 @@ class TestArrowHumanize:
         assert self.now.humanize(later, only_distance=True) == "an hour"
         assert later.humanize(self.now, only_distance=True) == "an hour"
 
+        assert self.now.humanize(later, brief=True) == "h"
+        assert later.humanize(self.now, brief=True) == "h"
+
     def test_hours(self):
 
         later = self.now.shift(hours=2)
@@ -2103,6 +2128,9 @@ class TestArrowHumanize:
 
         assert self.now.humanize(later, only_distance=True) == "2 hours"
         assert later.humanize(self.now, only_distance=True) == "2 hours"
+
+        assert self.now.humanize(later, brief=True) == "2h"
+        assert later.humanize(self.now, brief=True) == "2h"
 
     def test_day(self):
 
@@ -2126,6 +2154,9 @@ class TestArrowHumanize:
         assert self.now.humanize(later, only_distance=True) == "a day"
         assert later.humanize(self.now, only_distance=True) == "a day"
 
+        assert self.now.humanize(later, brief=True) == "d"
+        assert later.humanize(self.now, brief=True) == "d"
+
     def test_days(self):
 
         later = self.now.shift(days=2)
@@ -2135,6 +2166,9 @@ class TestArrowHumanize:
 
         assert self.now.humanize(later, only_distance=True) == "2 days"
         assert later.humanize(self.now, only_distance=True) == "2 days"
+
+        assert self.now.humanize(later, brief=True) == "2d"
+        assert later.humanize(self.now, brief=True) == "2d"
 
         # Regression tests for humanize bug referenced in issue 541
         later = self.now.shift(days=3)
@@ -2156,6 +2190,9 @@ class TestArrowHumanize:
         assert self.now.humanize(later, only_distance=True) == "a week"
         assert later.humanize(self.now, only_distance=True) == "a week"
 
+        assert self.now.humanize(later, brief=True) == "w"
+        assert later.humanize(self.now, brief=True) == "w"
+
     def test_weeks(self):
 
         later = self.now.shift(weeks=2)
@@ -2165,6 +2202,9 @@ class TestArrowHumanize:
 
         assert self.now.humanize(later, only_distance=True) == "2 weeks"
         assert later.humanize(self.now, only_distance=True) == "2 weeks"
+
+        assert self.now.humanize(later, brief=True) == "2w"
+        assert later.humanize(self.now, brief=True) == "2w"
 
     @pytest.mark.xfail(reason="known issue with humanize month limits")
     def test_month(self):
@@ -2177,6 +2217,9 @@ class TestArrowHumanize:
 
         assert self.now.humanize(later, only_distance=True) == "a month"
         assert later.humanize(self.now, only_distance=True) == "a month"
+
+        assert self.now.humanize(later, brief=True) == "m"
+        assert later.humanize(self.now, brief=True) == "m"
 
     def test_month_plus_4_days(self):
 
@@ -2198,6 +2241,9 @@ class TestArrowHumanize:
         assert self.now.humanize(later, only_distance=True) == "2 months"
         assert later.humanize(self.now, only_distance=True) == "2 months"
 
+        assert self.now.humanize(later, brief=True) == "2m"
+        assert later.humanize(self.now, brief=True) == "2m"
+
     def test_year(self):
 
         later = self.now.shift(years=1)
@@ -2208,6 +2254,9 @@ class TestArrowHumanize:
         assert self.now.humanize(later, only_distance=True) == "a year"
         assert later.humanize(self.now, only_distance=True) == "a year"
 
+        assert self.now.humanize(later, brief=True) == "y"
+        assert later.humanize(self.now, brief=True) == "y"
+
     def test_years(self):
 
         later = self.now.shift(years=2)
@@ -2217,6 +2266,9 @@ class TestArrowHumanize:
 
         assert self.now.humanize(later, only_distance=True) == "2 years"
         assert later.humanize(self.now, only_distance=True) == "2 years"
+
+        assert self.now.humanize(later, brief=True) == "2y"
+        assert later.humanize(self.now, brief=True) == "2y"
 
         arw = arrow.Arrow(2014, 7, 2)
 


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [x] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [x] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

- Added `brief` optional parameter to `humanize` function, based off #1001 
- Added associated tests inside `test_arrow.py`
- Updated documentation to reflect new feature

## Questions
Current implementation shortens into `only_distance` and then each term. One edge case that occurs for example is "an hour and 6 minutes" should that become "h 6m" or "1h 6m"

Closes #1001 

