### PR TITLE
Fix outdated Python 2 print in docs

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -759,7 +759,7 @@ class Arrow:
             >>> start = datetime(2013, 5, 5, 12, 30)
             >>> end = datetime(2013, 5, 5, 17, 15)
             >>> for r in arrow.Arrow.interval('hour', start, end, 2):
-            ...     print r
+            ...     print(r)
             ...
             (<Arrow [2013-05-05T12:00:00+00:00]>, <Arrow [2013-05-05T13:59:59.999999+00:00]>)
             (<Arrow [2013-05-05T14:00:00+00:00]>, <Arrow [2013-05-05T15:59:59.999999+00:00]>)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -315,7 +315,7 @@ You can also get a range of time spans:
     >>> start = datetime(2013, 5, 5, 12, 30)
     >>> end = datetime(2013, 5, 5, 17, 15)
     >>> for r in arrow.Arrow.span_range('hour', start, end):
-    ...     print r
+    ...     print(r)
     ...
     (<Arrow [2013-05-05T12:00:00+00:00]>, <Arrow [2013-05-05T12:59:59.999999+00:00]>)
     (<Arrow [2013-05-05T13:00:00+00:00]>, <Arrow [2013-05-05T13:59:59.999999+00:00]>)
@@ -330,7 +330,7 @@ Or just iterate over a range of time:
     >>> start = datetime(2013, 5, 5, 12, 30)
     >>> end = datetime(2013, 5, 5, 17, 15)
     >>> for r in arrow.Arrow.range('hour', start, end):
-    ...     print repr(r)
+    ...     print(repr(r))
     ...
     <Arrow [2013-05-05T12:30:00+00:00]>
     <Arrow [2013-05-05T13:30:00+00:00]>


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [ ] 🧪  Added **tests** for changed code.
- [ ] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [ ] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [ ] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

I noticed a Python 2 style print statement in docs, which this PR fixes.