### PR TITLE
feat(1090/default_tz): Added possibility to override default UTC - #1…

### DIFF
--- a/arrow/api.py
+++ b/arrow/api.py
@@ -9,6 +9,8 @@ from datetime import tzinfo as dt_tzinfo
 from time import struct_time
 from typing import Any, List, Optional, Tuple, Type, Union, overload
 
+from dateutil import tz as dateutil_tz
+
 from arrow.arrow import TZ_EXPR, Arrow
 from arrow.constants import DEFAULT_LOCALE
 from arrow.factory import ArrowFactory
@@ -26,6 +28,7 @@ def get(
     locale: str = DEFAULT_LOCALE,
     tzinfo: Optional[TZ_EXPR] = None,
     normalize_whitespace: bool = False,
+    default_tz: Optional[TZ_EXPR] = None,
 ) -> Arrow:
     ...  # pragma: no cover
 
@@ -36,6 +39,7 @@ def get(
     locale: str = DEFAULT_LOCALE,
     tzinfo: Optional[TZ_EXPR] = None,
     normalize_whitespace: bool = False,
+    default_tz: Optional[TZ_EXPR] = None,
 ) -> Arrow:
     ...  # pragma: no cover
 
@@ -57,6 +61,7 @@ def get(
     locale: str = DEFAULT_LOCALE,
     tzinfo: Optional[TZ_EXPR] = None,
     normalize_whitespace: bool = False,
+    default_tz: Optional[TZ_EXPR] = None,
 ) -> Arrow:
     ...  # pragma: no cover
 
@@ -69,6 +74,7 @@ def get(
     locale: str = DEFAULT_LOCALE,
     tzinfo: Optional[TZ_EXPR] = None,
     normalize_whitespace: bool = False,
+    default_tz: Optional[TZ_EXPR] = None,
 ) -> Arrow:
     ...  # pragma: no cover
 
@@ -81,6 +87,7 @@ def get(
     locale: str = DEFAULT_LOCALE,
     tzinfo: Optional[TZ_EXPR] = None,
     normalize_whitespace: bool = False,
+    default_tz: Optional[TZ_EXPR] = None,
 ) -> Arrow:
     ...  # pragma: no cover
 

--- a/arrow/factory.py
+++ b/arrow/factory.py
@@ -41,6 +41,7 @@ class ArrowFactory:
         locale: str = DEFAULT_LOCALE,
         tzinfo: Optional[TZ_EXPR] = None,
         normalize_whitespace: bool = False,
+        default_tz: Optional[TZ_EXPR] = None,
     ) -> Arrow:
         ...  # pragma: no cover
 
@@ -62,6 +63,7 @@ class ArrowFactory:
         locale: str = DEFAULT_LOCALE,
         tzinfo: Optional[TZ_EXPR] = None,
         normalize_whitespace: bool = False,
+        default_tz: Optional[TZ_EXPR] = None,
     ) -> Arrow:
         ...  # pragma: no cover
 
@@ -74,6 +76,7 @@ class ArrowFactory:
         locale: str = DEFAULT_LOCALE,
         tzinfo: Optional[TZ_EXPR] = None,
         normalize_whitespace: bool = False,
+        default_tz: Optional[TZ_EXPR] = None,
     ) -> Arrow:
         ...  # pragma: no cover
 
@@ -86,19 +89,21 @@ class ArrowFactory:
         locale: str = DEFAULT_LOCALE,
         tzinfo: Optional[TZ_EXPR] = None,
         normalize_whitespace: bool = False,
+        default_tz: Optional[TZ_EXPR] = None,
     ) -> Arrow:
         ...  # pragma: no cover
 
     def get(self, *args: Any, **kwargs: Any) -> Arrow:
         """Returns an :class:`Arrow <arrow.arrow.Arrow>` object based on flexible inputs.
 
-        :param locale: (optional) a ``str`` specifying a locale for the parser. Defaults to 'en-us'.
+        :param locale: (optional) a ``s
         :param tzinfo: (optional) a :ref:`timezone expression <tz-expr>` or tzinfo object.
             Replaces the timezone unless using an input form that is explicitly UTC or specifies
-            the timezone in a positional argument. Defaults to UTC.
+            the timezone in a positional argument.
         :param normalize_whitespace: (optional) a ``bool`` specifying whether or not to normalize
             redundant whitespace (spaces, tabs, and newlines) in a datetime string before parsing.
-            Defaults to false.
+            Defaults to false.tr`` specifying a locale for the parser. Defaults to 'en-us'.
+        :param default_tz: (optional) a :ref:`timezone expression <tz-expr>` that will be used on naive datetimes.
 
         Usage::
 
@@ -196,6 +201,7 @@ class ArrowFactory:
         arg_count = len(args)
         locale = kwargs.pop("locale", DEFAULT_LOCALE)
         tz = kwargs.get("tzinfo", None)
+        default_tz = kwargs.get("default_tz", None)
         normalize_whitespace = kwargs.pop("normalize_whitespace", False)
 
         # if kwargs given, send to constructor unless only tzinfo provided
@@ -203,19 +209,14 @@ class ArrowFactory:
             arg_count = 3
 
         # tzinfo kwarg is not provided
-        if len(kwargs) == 1 and tz is None:
+        if len(kwargs) == 1 and tz is None and default_tz is None:
             arg_count = 3
 
-        # () -> now, @ tzinfo or utc
+        # () -> now, @ tzinfo or default_tz or utc
         if arg_count == 0:
-            if isinstance(tz, str):
-                tz = parser.TzinfoParser.parse(tz)
-                return self.type.now(tzinfo=tz)
-
-            if isinstance(tz, dt_tzinfo):
-                return self.type.now(tzinfo=tz)
-
-            return self.type.utcnow()
+            if default_tz is None:
+                default_tz = dateutil_tz.tzutc()
+            return self.type.now(default_tz=default_tz, tzinfo=tz)
 
         if arg_count == 1:
             arg = args[0]
@@ -228,22 +229,19 @@ class ArrowFactory:
 
             # try (int, float) -> from timestamp @ tzinfo
             elif not isinstance(arg, str) and is_timestamp(arg):
-                if tz is None:
-                    # set to UTC by default
-                    tz = dateutil_tz.tzutc()
-                return self.type.fromtimestamp(arg, tzinfo=tz)
+                return self.type.fromtimestamp(arg, default_tz=default_tz, tzinfo=tz)
 
             # (Arrow) -> from the object's datetime @ tzinfo
             elif isinstance(arg, Arrow):
-                return self.type.fromdatetime(arg.datetime, tzinfo=tz)
+                return self.type.fromdatetime(arg.datetime, default_tz=default_tz, tzinfo=tz)
 
             # (datetime) -> from datetime @ tzinfo
             elif isinstance(arg, datetime):
-                return self.type.fromdatetime(arg, tzinfo=tz)
+                return self.type.fromdatetime(arg, default_tz=default_tz, tzinfo=tz)
 
             # (date) -> from date @ tzinfo
             elif isinstance(arg, date):
-                return self.type.fromdate(arg, tzinfo=tz)
+                return self.type.fromdate(arg, default_tz=default_tz, tzinfo=tz)
 
             # (tzinfo) -> now @ tzinfo
             elif isinstance(arg, dt_tzinfo):
@@ -252,7 +250,7 @@ class ArrowFactory:
             # (str) -> parse @ tzinfo
             elif isinstance(arg, str):
                 dt = parser.DateTimeParser(locale).parse_iso(arg, normalize_whitespace)
-                return self.type.fromdatetime(dt, tzinfo=tz)
+                return self.type.fromdatetime(dt, default_tz=default_tz, tzinfo=tz)
 
             # (struct_time) -> from struct_time
             elif isinstance(arg, struct_time):
@@ -261,7 +259,7 @@ class ArrowFactory:
             # (iso calendar) -> convert then from date @ tzinfo
             elif isinstance(arg, tuple) and len(arg) == 3:
                 d = iso_to_gregorian(*arg)
-                return self.type.fromdate(d, tzinfo=tz)
+                return self.type.fromdate(d, default_tz=default_tz, tzinfo=tz)
 
             else:
                 raise TypeError(f"Cannot parse single argument of type {type(arg)!r}.")
@@ -274,7 +272,7 @@ class ArrowFactory:
 
                 # (datetime, tzinfo/str) -> fromdatetime @ tzinfo
                 if isinstance(arg_2, (dt_tzinfo, str)):
-                    return self.type.fromdatetime(arg_1, tzinfo=arg_2)
+                    return self.type.fromdatetime(arg_1, default_tz=default_tz, tzinfo=arg_2)
                 else:
                     raise TypeError(
                         f"Cannot parse two arguments of types 'datetime', {type(arg_2)!r}."
@@ -284,7 +282,7 @@ class ArrowFactory:
 
                 # (date, tzinfo/str) -> fromdate @ tzinfo
                 if isinstance(arg_2, (dt_tzinfo, str)):
-                    return self.type.fromdate(arg_1, tzinfo=arg_2)
+                    return self.type.fromdate(arg_1, default_tz=default_tz, tzinfo=arg_2)
                 else:
                     raise TypeError(
                         f"Cannot parse two arguments of types 'date', {type(arg_2)!r}."
@@ -295,7 +293,7 @@ class ArrowFactory:
                 dt = parser.DateTimeParser(locale).parse(
                     args[0], args[1], normalize_whitespace
                 )
-                return self.type.fromdatetime(dt, tzinfo=tz)
+                return self.type.fromdatetime(dt, default_tz=default_tz, tzinfo=tz)
 
             else:
                 raise TypeError(
@@ -340,9 +338,4 @@ class ArrowFactory:
             <Arrow [2013-05-07T22:19:39.130059-07:00]>
         """
 
-        if tz is None:
-            tz = dateutil_tz.tzlocal()
-        elif not isinstance(tz, dt_tzinfo):
-            tz = parser.TzinfoParser.parse(tz)
-
-        return self.type.now(tz)
+        return self.type.now(default_tz=dateutil_tz.tzlocal(), tzinfo=tz)

--- a/arrow/util.py
+++ b/arrow/util.py
@@ -1,10 +1,12 @@
 """Helpful functions used internally within arrow."""
 
 import datetime
-from typing import Any, Optional, cast
+from datetime import tzinfo as dt_tzinfo, datetime as dt_datetime
+from typing import Any, Optional, cast, Tuple, Union
 
 from dateutil.rrule import WEEKLY, rrule
 
+from arrow import parser
 from arrow.constants import (
     MAX_ORDINAL,
     MAX_TIMESTAMP,
@@ -115,3 +117,39 @@ def validate_bounds(bounds: str) -> None:
 
 
 __all__ = ["next_weekday", "is_timestamp", "validate_ordinal", "iso_to_gregorian"]
+
+
+def get_tzinfo_default_used(
+        default_tz: Union[dt_tzinfo, str],
+        dt: Optional[dt_datetime] = None,
+        tzinfo: Optional[Union[dt_tzinfo, str]] = None
+) -> Tuple[dt_tzinfo, bool]:
+    """Get the tzinfo to use, and indicate if it was based on ``default_tz``.
+
+    :param default_tz: A :ref:`timezone expression <tz-expr>` that will be used on naive datetimes.
+    :param dt: (optional) a ``datetime`` object.
+    :param tzinfo: (optional) a ``tzinfo`` object.
+    """
+
+    default_tz_used = False
+
+    if tzinfo is None:
+        if dt and dt.tzinfo:
+            tzinfo = dt.tzinfo
+
+        else:
+            tzinfo = default_tz
+            default_tz_used = True
+
+    # detect that tzinfo is a pytz object (issue #626)
+    if (
+            isinstance(tzinfo, dt_tzinfo)
+            and hasattr(tzinfo, "localize")
+            and hasattr(tzinfo, "zone")
+            and tzinfo.zone  # type: ignore[attr-defined]
+    ):
+        tzinfo = parser.TzinfoParser.parse(tzinfo.zone)  # type: ignore[attr-defined]
+    elif isinstance(tzinfo, str):
+        tzinfo = parser.TzinfoParser.parse(tzinfo)
+
+    return tzinfo, default_tz_used

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,6 +60,16 @@ Parse from a string:
     >>> arrow.get('2013-05-05 12:30:45', 'YYYY-MM-DD HH:mm:ss')
     <Arrow [2013-05-05T12:30:45+00:00]>
 
+It is possible to override the default UTC timezone for a naive datetime
+(any timezone-aware datetime will keep it's original timezone):
+
+.. code-block:: python
+
+    >>> arrow.get('2013-05-05 12:30:45', 'YYYY-MM-DD HH:mm:ss', default_tz='US/Pacific')
+    <Arrow [2013-05-05T12:30:45-07:00]>
+    >>> arrow.get('2013-05-05 12:30:45Z', 'YYYY-MM-DD HH:mm:ssZ', default_tz='US/Pacific')
+    <Arrow [2013-05-05T12:30:45+00:00]>
+
 Search a date in a string:
 
 .. code-block:: python

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -81,6 +81,50 @@ class TestTestArrowInit:
         assert before == after
         assert before.utcoffset() != after.utcoffset()
 
+    def test_init_default_tz(self):
+
+        result = arrow.Arrow(2013, 2, 2, 12, 30, 45, 999999, default_tz=tz.gettz("Europe/Oslo"))
+        self.expected = datetime(
+            2013, 2, 2, 12, 30, 45, 999999, tzinfo=tz.gettz("Europe/Oslo")
+        )
+        assert result._datetime == self.expected
+        assert_datetime_equality(result._datetime, self.expected, 1)
+        assert result.default_tz_used
+        assert result.default_tz == tz.gettz("Europe/Oslo")
+
+    def test_init_default_tz_string(self):
+
+        result = arrow.Arrow(2013, 2, 2, 12, 30, 45, 999999, default_tz="Europe/Oslo")
+        self.expected = datetime(
+            2013, 2, 2, 12, 30, 45, 999999, tzinfo=tz.gettz("Europe/Oslo")
+        )
+        assert result._datetime == self.expected
+        assert_datetime_equality(result._datetime, self.expected, 1)
+        assert result.default_tz_used
+        assert result.default_tz == "Europe/Oslo"
+
+    def test_init_default_tz_none(self):
+
+        result = arrow.Arrow(2013, 2, 2, 12, 30, 45, 999999)
+        self.expected = datetime(
+            2013, 2, 2, 12, 30, 45, 999999, tzinfo=tz.tzutc()
+        )
+        assert result._datetime == self.expected
+        assert_datetime_equality(result._datetime, self.expected, 1)
+        assert result.default_tz_used is True
+        assert result.default_tz == tz.tzutc()
+
+    def test_init_default_tz_existing_tzinfo(self):
+
+        result = arrow.Arrow(2013, 2, 2, 12, 30, 45, 999999, tzinfo=tz.tzutc(), default_tz=tz.gettz("Europe/Oslo"))
+        self.expected = datetime(
+            2013, 2, 2, 12, 30, 45, 999999, tzinfo=tz.tzutc()
+        )
+        assert result._datetime == self.expected
+        assert_datetime_equality(result._datetime, self.expected, 1)
+        assert result.default_tz_used is False
+        assert result.default_tz == tz.gettz("Europe/Oslo")
+
 
 class TestTestArrowFactory:
     def test_now(self):

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -90,6 +90,15 @@ class TestGet:
             self.factory.get(timestamp, tzinfo=timezone), timestamp_dt
         )
 
+    def test_one_arg_str(self):
+
+        result = self.factory.get("1990-01-01 12:30:45")
+        self.expected = datetime(1990, 1, 1, 12, 30, 45).replace(tzinfo=tz.tzutc())
+
+        assert_datetime_equality(result, self.expected)
+        assert result.default_tz == tz.tzutc()
+        assert result.default_tz_used
+
     def test_one_arg_arrow(self):
 
         arw = self.factory.utcnow()
@@ -155,6 +164,36 @@ class TestGet:
 
         with pytest.raises(ParserError):
             self.factory.get(tzinfo="US/PacificInvalidTzinfo")
+
+    def test_kwarg_default_tz(self):
+
+        self.expected = (
+            datetime.now()
+            .astimezone(tz.gettz("Europe/Oslo"))
+        )
+
+        assert_datetime_equality(
+            self.factory.get(default_tz=tz.gettz("Europe/Oslo")), self.expected
+        )
+
+    def test_kwarg_default_tz_string(self):
+
+        self.expected = (
+            datetime.now()
+            .astimezone(tz.gettz("Europe/Oslo"))
+        )
+
+        assert_datetime_equality(self.factory.get(default_tz="Europe/Oslo"), self.expected)
+
+        with pytest.raises(ParserError):
+            self.factory.get(default_tz="Europe/OsloInvalidTzinfo")
+
+    def test_kwarg_default_tz_string_existing_tzinfo(self):
+
+        self.expected = datetime(1990, 1, 1, 12, 30, 45).replace(tzinfo=tz.tzutc())
+
+        assert_datetime_equality(self.factory.get("1990-01-01 12:30:45+00:00", default_tz="Europe/Oslo"), self.expected)
+
 
     def test_kwarg_normalize_whitespace(self):
         result = self.factory.get(


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [x] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [x] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

https://github.com/arrow-py/arrow/issues/1090 - Added possibility to override default UTC timezone. I don't believe this should be breaking anything, but I appretiate any feedback as this is my first PR on such a project.

Closes: #1090
