### PR TITLE
add support for Python 3.11

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.7", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["pypy-3.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11-dev"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
           # pypy3 randomly fails on Windows builds

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     keywords="arrow date time datetime timestamp timezone humanize",
     project_urls={

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
-    3.11-dev: py311
+    3.11: py311
 
 [testenv]
 deps = -r requirements/requirements-tests.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.18.0
-envlist = py{py3,36,37,38,39,310}
+envlist = py{py3,36,37,38,39,310,311}
 skip_missing_interpreters = true
 
 [gh-actions]
@@ -11,6 +11,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11-dev: py311
 
 [testenv]
 deps = -r requirements/requirements-tests.txt


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [ ] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

Happy to get the chance to finally contribute something to this great project 🎉 

- Added support of Python 3.11. Was pretty easy, no deprecation warnings popped up, at least I didn't see them 😄 
- Added the Python 3.11 classifier

When Python 3.11 will be finally released, then the `dev` suffix for GHA should be removed.
