### PR TITLE
Upgrade mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
       - id: flake8
         additional_dependencies: [flake8-bugbear,flake8-annotations]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.950'
+    rev: v0.982
     hooks:
       - id: mypy
         additional_dependencies: [types-python-dateutil]

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -495,7 +495,7 @@ class Arrow:
             yield current
 
             values = [getattr(current, f) for f in cls._ATTRS]
-            current = cls(*values, tzinfo=tzinfo).shift(  # type: ignore
+            current = cls(*values, tzinfo=tzinfo).shift(  # type: ignore[misc]
                 **{frame_relative: relative_steps}
             )
 
@@ -578,7 +578,7 @@ class Arrow:
             for _ in range(3 - len(values)):
                 values.append(1)
 
-            floor = self.__class__(*values, tzinfo=self.tzinfo)  # type: ignore
+            floor = self.__class__(*values, tzinfo=self.tzinfo)  # type: ignore[misc]
 
             if frame_absolute == "week":
                 # if week_start is greater than self.isoweekday() go back one week by setting delta = 7
@@ -1259,7 +1259,7 @@ class Arrow:
                     )
 
                 if trunc(abs(delta)) != 1:
-                    granularity += "s"  # type: ignore
+                    granularity += "s"  # type: ignore[assignment]
                 return locale.describe(granularity, delta, only_distance=only_distance)
 
             else:

--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -4121,6 +4121,7 @@ class BengaliLocale(Locale):
             return f"{n}র্থ"
         if n == 6:
             return f"{n}ষ্ঠ"
+        return ""
 
 
 class RomanshLocale(Locale):

--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -187,7 +187,7 @@ class DateTimeParser:
             }
         )
         if cache_size > 0:
-            self._generate_pattern_re = lru_cache(maxsize=cache_size)(  # type: ignore
+            self._generate_pattern_re = lru_cache(maxsize=cache_size)(  # type: ignore[assignment]
                 self._generate_pattern_re
             )
 
@@ -341,7 +341,7 @@ class DateTimeParser:
                     f"Unable to find a match group for the specified token {token!r}."
                 )
 
-            self._parse_token(token, value, parts)  # type: ignore
+            self._parse_token(token, value, parts)  # type: ignore[arg-type]
 
         return self._build_datetime(parts)
 
@@ -508,7 +508,7 @@ class DateTimeParser:
 
         elif token in ["MMMM", "MMM"]:
             # FIXME: month_number() is nullable
-            parts["month"] = self.locale.month_number(value.lower())  # type: ignore
+            parts["month"] = self.locale.month_number(value.lower())  # type: ignore[typeddict-item]
 
         elif token in ["MM", "M"]:
             parts["month"] = int(value)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,9 @@
 [mypy]
 python_version = 3.6
 
+show_error_codes = True
+pretty = True
+
 allow_any_expr = True
 allow_any_decorated = True
 allow_any_explicit = True

--- a/tests/test_locales.py
+++ b/tests/test_locales.py
@@ -1394,7 +1394,7 @@ class TestBengaliLocale:
         assert self.locale._ordinal_number(10) == "10ম"
         assert self.locale._ordinal_number(11) == "11তম"
         assert self.locale._ordinal_number(42) == "42তম"
-        assert self.locale._ordinal_number(-1) is None
+        assert self.locale._ordinal_number(-1) == ""
 
 
 @pytest.mark.usefixtures("lang_locale")


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [ ] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

- Upgrade `mypy` to the newest version, because it has some nice improvements
- The newest `mypy` found a typing issue with `_ordinal_number` for `BengaliLocale`, which is correct, because it would return `None` if a negative number is passed in. This behaviour doesn't fit other locales, like `OdiaLocale` and `TamilLocale` one. I hope I made the right call here to change the return value to an empty string
- Also added error codes to the `type: ignore` comments to not automatically ignore other typing issue in the same line
- Also adjusted the `mypy` config to show the error code, when there is a typing issue and do it pretty 😄 that's how it would look like
```shell
arrow/arrow.py:173: error: "tzinfo" has no attribute "zone"  [attr-defined]
                tzinfo = parser.TzinfoParser.parse(tzinfo.zone)
                                                   ^
```
