### PR TITLE
Cython

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: auto test docs clean
+.PHONY: auto test docs clean compile-cython
 
 auto: build310
 
@@ -16,6 +16,10 @@ build36 build37 build38 build39 build310: clean
 	pip install -r requirements/requirements-tests.txt; \
 	pip install -r requirements/requirements-docs.txt; \
 	pre-commit install
+
+compile-cython:
+	. venv/bin/activate; \
+	python setup.py build_ext --inplace
 
 test:
 	rm -f .coverage coverage.xml
@@ -45,7 +49,7 @@ clean: clean-dist
 clean-dist:
 	rm -rf dist build .egg .eggs arrow.egg-info
 
-build-dist:
+build-dist: compile-cython
 	. venv/bin/activate; \
 	pip install -U pip setuptools twine wheel; \
 	python setup.py sdist bdist_wheel

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -1148,7 +1148,7 @@ class Arrow:
         """
 
         locale_name = locale
-        locale = locales.get_locale(locale)
+        locale_cls = locales.get_locale(locale)
 
         if other is None:
             utc = dt_datetime.utcnow().replace(tzinfo=dateutil_tz.tzutc())
@@ -1179,41 +1179,55 @@ class Arrow:
         try:
             if granularity == "auto":
                 if diff < 10:
-                    return locale.describe("now", only_distance=only_distance)
+                    return locale_cls.describe("now", only_distance=only_distance)
 
                 if diff < self._SECS_PER_MINUTE:
                     seconds = sign * delta_second
-                    return locale.describe(
+                    return locale_cls.describe(
                         "seconds", seconds, only_distance=only_distance
                     )
 
                 elif diff < self._SECS_PER_MINUTE * 2:
-                    return locale.describe("minute", sign, only_distance=only_distance)
+                    return locale_cls.describe(
+                        "minute", sign, only_distance=only_distance
+                    )
                 elif diff < self._SECS_PER_HOUR:
                     minutes = sign * max(delta_second // self._SECS_PER_MINUTE, 2)
-                    return locale.describe(
+                    return locale_cls.describe(
                         "minutes", minutes, only_distance=only_distance
                     )
 
                 elif diff < self._SECS_PER_HOUR * 2:
-                    return locale.describe("hour", sign, only_distance=only_distance)
+                    return locale_cls.describe(
+                        "hour", sign, only_distance=only_distance
+                    )
                 elif diff < self._SECS_PER_DAY:
                     hours = sign * max(delta_second // self._SECS_PER_HOUR, 2)
-                    return locale.describe("hours", hours, only_distance=only_distance)
+                    return locale_cls.describe(
+                        "hours", hours, only_distance=only_distance
+                    )
                 elif diff < self._SECS_PER_DAY * 2:
-                    return locale.describe("day", sign, only_distance=only_distance)
+                    return locale_cls.describe("day", sign, only_distance=only_distance)
                 elif diff < self._SECS_PER_WEEK:
                     days = sign * max(delta_second // self._SECS_PER_DAY, 2)
-                    return locale.describe("days", days, only_distance=only_distance)
+                    return locale_cls.describe(
+                        "days", days, only_distance=only_distance
+                    )
 
                 elif diff < self._SECS_PER_WEEK * 2:
-                    return locale.describe("week", sign, only_distance=only_distance)
+                    return locale_cls.describe(
+                        "week", sign, only_distance=only_distance
+                    )
                 elif diff < self._SECS_PER_MONTH:
                     weeks = sign * max(delta_second // self._SECS_PER_WEEK, 2)
-                    return locale.describe("weeks", weeks, only_distance=only_distance)
+                    return locale_cls.describe(
+                        "weeks", weeks, only_distance=only_distance
+                    )
 
                 elif diff < self._SECS_PER_MONTH * 2:
-                    return locale.describe("month", sign, only_distance=only_distance)
+                    return locale_cls.describe(
+                        "month", sign, only_distance=only_distance
+                    )
                 elif diff < self._SECS_PER_YEAR:
                     # TODO revisit for humanization during leap years
                     self_months = self._datetime.year * 12 + self._datetime.month
@@ -1221,15 +1235,19 @@ class Arrow:
 
                     months = sign * max(abs(other_months - self_months), 2)
 
-                    return locale.describe(
+                    return locale_cls.describe(
                         "months", months, only_distance=only_distance
                     )
 
                 elif diff < self._SECS_PER_YEAR * 2:
-                    return locale.describe("year", sign, only_distance=only_distance)
+                    return locale_cls.describe(
+                        "year", sign, only_distance=only_distance
+                    )
                 else:
                     years = sign * max(delta_second // self._SECS_PER_YEAR, 2)
-                    return locale.describe("years", years, only_distance=only_distance)
+                    return locale_cls.describe(
+                        "years", years, only_distance=only_distance
+                    )
 
             elif isinstance(granularity, str):
                 granularity = cast(TimeFrameLiteral, granularity)  # type: ignore[assignment]
@@ -1237,7 +1255,7 @@ class Arrow:
                 if granularity == "second":
                     delta = sign * float(delta_second)
                     if abs(delta) < 2:
-                        return locale.describe("now", only_distance=only_distance)
+                        return locale_cls.describe("now", only_distance=only_distance)
                 elif granularity == "minute":
                     delta = sign * delta_second / self._SECS_PER_MINUTE
                 elif granularity == "hour":
@@ -1260,7 +1278,9 @@ class Arrow:
 
                 if trunc(abs(delta)) != 1:
                     granularity += "s"  # type: ignore[assignment]
-                return locale.describe(granularity, delta, only_distance=only_distance)
+                return locale_cls.describe(
+                    granularity, delta, only_distance=only_distance
+                )
 
             else:
 
@@ -1304,7 +1324,9 @@ class Arrow:
                         "Please select between 'second', 'minute', 'hour', 'day', 'week', 'month', 'quarter' or 'year'."
                     )
 
-                return locale.describe_multi(timeframes, only_distance=only_distance)
+                return locale_cls.describe_multi(
+                    timeframes, only_distance=only_distance
+                )
 
         except KeyError as e:
             raise ValueError(
@@ -1410,9 +1432,7 @@ class Arrow:
 
                 # Add change value to the correct unit (incorporates the plurality that exists within timeframe i.e second v.s seconds)
                 time_unit_to_change = str(unit)
-                time_unit_to_change += (
-                    "s" if (str(time_unit_to_change)[-1] != "s") else ""
-                )
+                time_unit_to_change += "s" if time_unit_to_change[-1] != "s" else ""
                 time_object_info[time_unit_to_change] = change_value
                 unit_visited[time_unit_to_change] = True
 
@@ -1663,7 +1683,8 @@ class Arrow:
 
         """
 
-        return self._datetime.isocalendar()
+        cal = tuple(self._datetime.isocalendar())
+        return (cal[0], cal[1], cal[2])
 
     def isoformat(self, sep: str = "T", timespec: str = "auto") -> str:
         """Returns an ISO 8601 formatted representation of the date and time.

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,2 +1,3 @@
+Cython>=3.0.0a11
 python-dateutil>=2.7.0
 typing_extensions; python_version < '3.8'

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ extensions = [
     Extension(
         "*",
         ["arrow/*.py"],
+        define_macros=[("CYTHON_TRACE", "1")],
     )
 ]
 
@@ -54,6 +55,8 @@ setup(
         "Bug Reports": "https://github.com/arrow-py/arrow/issues",
         "Documentation": "https://arrow.readthedocs.io",
     },
-    ext_modules=cythonize(extensions, language_level="3"),
+    ext_modules=cythonize(
+        extensions, language_level="3", compiler_directives={"linetrace": True}
+    ),
     cmdclass={"build_ext": build_ext},
 )

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,20 @@
 # mypy: ignore-errors
 from pathlib import Path
 
-from setuptools import setup
+from Cython.Build import build_ext, cythonize
+from setuptools import Extension, setup
 
 readme = Path("README.rst").read_text(encoding="utf-8")
 version = Path("arrow/_version.py").read_text(encoding="utf-8")
 about = {}
 exec(version, about)
+
+extensions = [
+    Extension(
+        "*",
+        ["arrow/*.py"],
+    )
+]
 
 setup(
     name="arrow",
@@ -46,4 +54,6 @@ setup(
         "Bug Reports": "https://github.com/arrow-py/arrow/issues",
         "Documentation": "https://arrow.readthedocs.io",
     },
+    ext_modules=cythonize(extensions, language_level="3"),
+    cmdclass={"build_ext": build_ext},
 )

--- a/tests/test_locales.py
+++ b/tests/test_locales.py
@@ -77,13 +77,10 @@ class TestModule:
         mock_locale_cls = mocker.Mock()
         mock_locale_obj = mock_locale_cls.return_value = mocker.Mock()
 
-        globals_fn = mocker.Mock()
-        globals_fn.return_value = {"NonExistentLocale": mock_locale_cls}
-
         with pytest.raises(ValueError):
             arrow.locales.get_locale_by_class_name("NonExistentLocale")
 
-        mocker.patch.object(locales, "globals", globals_fn)
+        mocker.patch.object(locales, "NonExistentLocale", mock_locale_cls, create=True)
         result = arrow.locales.get_locale_by_class_name("NonExistentLocale")
 
         mock_locale_cls.assert_called_once_with()

--- a/tox.ini
+++ b/tox.ini
@@ -47,3 +47,6 @@ include_trailing_comma = true
 [flake8]
 per-file-ignores = arrow/__init__.py:F401,tests/*:ANN001,ANN201
 ignore = E203,E501,W503,ANN101,ANN102,ANN401
+
+[coverage:run]
+plugins = Cython.Coverage


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [ ] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

These changes were made in collaboration with @khanm3

- Modified the setup file so that the entire Arrow library is compiled using Cython
- Modified the tox.ini file to support code coverage with Cython
- Added Cython 3.0.0a11 to the requirements.txt
- Modified arrow.py to compile with Cython and pass the test suite
- Modified an existing test case to work with Cython since the mocking was broken from Cython caching builtins
- Added a Makefile target to compile with Cython

This pull requests add Cython support to Arrow as requested by #617. 

## Further Explanation

In arrow/arrow.py, we had to change the variable "locale" to "local_cls" because the variable was being reused for 2 different types and this functionality was incompatible with Cython. Cython also had difficulties recognizing the type of _datetime.isoclanedar, so we had to specifically cast it to a tuple. Without this, it would not compile. 

Even with the issues mentioned above, we chose to use Cython 3.0.0a11 (which is a pre-release version) instead of Cython 0.29.32 (the most recent stable version), since from our testing, Cython 3 is better at parsing modern Python features. In general, Cython tries to subsume the functionality of python, but as you can see there are still many quirks.

We were able to allow Cython to use the existing method of calculating code coverage by adding linetracing as a compiler directive. However, due to the quirks of Cython, the resulting line coverage results are slightly lower than 100%. We found that the lines that were no longer being covered were one of 2 cases:
1) Inside an if statement that had 'pragma no cover' (so those also shouldn't count towards coverage)
2) Parameters to functions that had a default value (which also shouldn't count towards coverage, but for some reason Cython thinks it should)

This could be ignored by adding more 'pragma no cover', but we're not sure if there is a better way.

## Performance Analysis

To compare performance of Arrow with and without Cython, we ran just the Arrow part of [this benchmark](https://gist.github.com/freach/5490d8c0f86a0fff99e0b3e0d34205ad). This benchmark runs 1 million executions per benchmark and picked the min of 5 repeats. This was run in Python 3.8.10.

![arrow_benchmark](https://user-images.githubusercontent.com/90070416/202951883-8e8f3d0f-3f4e-4aa8-ad1b-0f7baceffc57.png)

From these results, you can see that compiling Arrow with Cython does cause a measureable improvement to performance, especially with parsing. Additionally, compiling Cython without linetracing is even more performant, but we currently compile with it so that code coverage can be calculated.

## Future Work

Adding static typing (and necessarily converting those files to .pyx files) would bring an even bigger boost to performance. Parser.py should receive special attention, as this is where the largest amount of time is being spend. This is where adding Cython to Arrow could prove to be especially valuable, since the speed increase with static typing should be much more than that gain by simply compiling with Cython. Looking into different ways of calculating code coverage so linetracing is no longer needed, or providing an option to switch the compiler directive would also be a good way to improve performance in the future.