### PR TITLE
Added support for Elasticsearch datetime format

### DIFF
--- a/arrow/__init__.py
+++ b/arrow/__init__.py
@@ -13,6 +13,7 @@ from .formatter import (
     FORMAT_RFC3339,
     FORMAT_RSS,
     FORMAT_W3C,
+    FORMAT_ES,
 )
 from .parser import ParserError
 
@@ -35,5 +36,6 @@ __all__ = [
     "FORMAT_RFC3339",
     "FORMAT_RSS",
     "FORMAT_W3C",
+    "FORMAT_ES",
     "ParserError",
 ]

--- a/arrow/formatter.py
+++ b/arrow/formatter.py
@@ -26,6 +26,7 @@ FORMAT_RFC2822: Final[str] = "ddd, DD MMM YYYY HH:mm:ss Z"
 FORMAT_RFC3339: Final[str] = "YYYY-MM-DD HH:mm:ssZZ"
 FORMAT_RSS: Final[str] = "ddd, DD MMM YYYY HH:mm:ss Z"
 FORMAT_W3C: Final[str] = "YYYY-MM-DD HH:mm:ssZZ"
+FORMAT_ES: Final[str] = "yyyy-MM-dd HH:mm:ss.SSSZ"
 
 
 class DateTimeFormatter:
@@ -35,7 +36,7 @@ class DateTimeFormatter:
     # emulated in Python's re library, see https://stackoverflow.com/a/13577411/2701578
 
     _FORMAT_RE: Final[Pattern[str]] = re.compile(
-        r"(\[(?:(?=(?P<literal>[^]]))(?P=literal))*\]|YYY?Y?|MM?M?M?|Do|DD?D?D?|d?dd?d?|HH?|hh?|mm?|ss?|SS?S?S?S?S?|ZZ?Z?|a|A|X|x|W)"
+        r"(\[(?:(?=(?P<literal>[^]]))(?P=literal))*\]|YYY?Y?|yyy?y?|MM?M?M?|Do|DD?D?D?|d?dd?d?|HH?|hh?|mm?|ss?|SS?S?S?S?S?|ZZ?Z?|a|A|X|x|W)"
     )
 
     locale: locales.Locale
@@ -56,9 +57,9 @@ class DateTimeFormatter:
         if token and token.startswith("[") and token.endswith("]"):
             return token[1:-1]
 
-        if token == "YYYY":
+        if token in ("YYYY", "yyyy"):
             return self.locale.year_full(dt.year)
-        if token == "YY":
+        if token in ("YY", "yy"):
             return self.locale.year_abbreviation(dt.year)
 
         if token == "MMMM":
@@ -74,7 +75,7 @@ class DateTimeFormatter:
             return f"{dt.timetuple().tm_yday:03d}"
         if token == "DDD":
             return f"{dt.timetuple().tm_yday}"
-        if token == "DD":
+        if token in ("DD", "dd"):
             return f"{dt.day:02d}"
         if token == "D":
             return f"{dt.day}"

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -15,6 +15,7 @@ from arrow import (
     FORMAT_RFC3339,
     FORMAT_RSS,
     FORMAT_W3C,
+    FORMAT_ES,
 )
 
 from .utils import make_full_tz_list
@@ -277,4 +278,10 @@ class TestFormatterBuiltinFormats:
         assert (
             self.formatter.format(self.datetime, FORMAT_W3C)
             == "1975-12-25 14:15:16-05:00"
+        )
+
+    def test_elasticsearch(self):
+        assert (
+            self.formatter.format(self.datetime, FORMAT_ES)
+            == "1975-12-25 14:15:16.000-0500"
         )


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [x] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [x] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes
Added support for Elastcisearch build in datetime [format](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html#built-in-date-formats), For example `yyyy-MM-dd HH:mm:ss.SSSZ`