### PR TITLE
Fix type signature of Arrow.__getattr__

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -802,7 +802,7 @@ class Arrow:
 
     # attributes and properties
 
-    def __getattr__(self, name: str) -> int:
+    def __getattr__(self, name: str) -> Any:
         if name == "week":
             return self.isocalendar()[1]
 
@@ -810,7 +810,7 @@ class Arrow:
             return int((self.month - 1) / self._MONTHS_PER_QUARTER) + 1
 
         if not name.startswith("_"):
-            value: Optional[int] = getattr(self._datetime, name, None)
+            value: Optional[Any] = getattr(self._datetime, name, None)
 
             if value is not None:
                 return value
@@ -1862,7 +1862,7 @@ class Arrow:
     @staticmethod
     def _is_last_day_of_month(date: "Arrow") -> bool:
         """Returns a boolean indicating whether the datetime is the last day of the month."""
-        return date.day == calendar.monthrange(date.year, date.month)[1]
+        return cast(int, date.day) == calendar.monthrange(date.year, date.month)[1]
 
 
 Arrow.min = Arrow.fromdatetime(dt_datetime.min)


### PR DESCRIPTION
## Pull Request Checklist

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [ ] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

## Description of Changes

Arrow's `__getattr__` provides access to `datetime` attributes that aren't handled by Arrow.
It has this signature:
```python
def __getattr__(self, name: str) -> int
```
It should return `Any`, as not all attributes from `datetime` are `int`s.

For example, in `arrow.now().tzname()`, `tzname` is a function.

I noticed that `__getattr__` implements two undocumented attributes: `week` and `quarter`. The should be split into their own methods, with a docstring.