### PR TITLE
Remove typing_extensions

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -18,9 +18,11 @@ from time import struct_time
 from typing import (
     Any,
     ClassVar,
+    Final,
     Generator,
     Iterable,
     List,
+    Literal,
     Mapping,
     Optional,
     Tuple,
@@ -35,12 +37,6 @@ from dateutil.relativedelta import relativedelta
 from arrow import formatter, locales, parser, util
 from arrow.constants import DEFAULT_LOCALE, DEHUMANIZE_LOCALES
 from arrow.locales import TimeFrameLiteral
-
-if sys.version_info < (3, 8):  # pragma: no cover
-    from typing_extensions import Final, Literal
-else:
-    from typing import Final, Literal  # pragma: no cover
-
 
 TZ_EXPR = Union[dt_tzinfo, str]
 

--- a/arrow/constants.py
+++ b/arrow/constants.py
@@ -2,11 +2,7 @@
 
 import sys
 from datetime import datetime
-
-if sys.version_info < (3, 8):  # pragma: no cover
-    from typing_extensions import Final
-else:
-    from typing import Final  # pragma: no cover
+from typing import Final
 
 # datetime.max.timestamp() errors on Windows, so we must hardcode
 # the highest possible datetime value that can output a timestamp.

--- a/arrow/formatter.py
+++ b/arrow/formatter.py
@@ -1,20 +1,13 @@
 """Provides the :class:`Arrow <arrow.formatter.DateTimeFormatter>` class, an improved formatter for datetimes."""
 
 import re
-import sys
 from datetime import datetime, timedelta
-from typing import Optional, Pattern, cast
+from typing import Final, Optional, Pattern, cast
 
 from dateutil import tz as dateutil_tz
 
 from arrow import locales
 from arrow.constants import DEFAULT_LOCALE
-
-if sys.version_info < (3, 8):  # pragma: no cover
-    from typing_extensions import Final
-else:
-    from typing import Final  # pragma: no cover
-
 
 FORMAT_ATOM: Final[str] = "YYYY-MM-DD HH:mm:ssZZ"
 FORMAT_COOKIE: Final[str] = "dddd, DD-MMM-YYYY HH:mm:ss ZZZ"

--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -1,12 +1,12 @@
 """Provides internationalization for arrow in over 60 languages and dialects."""
 
-import sys
 from math import trunc
 from typing import (
     Any,
     ClassVar,
     Dict,
     List,
+    Literal,
     Mapping,
     Optional,
     Sequence,
@@ -15,11 +15,6 @@ from typing import (
     Union,
     cast,
 )
-
-if sys.version_info < (3, 8):  # pragma: no cover
-    from typing_extensions import Literal
-else:
-    from typing import Literal  # pragma: no cover
 
 TimeFrameLiteral = Literal[
     "now",

--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -1,7 +1,6 @@
 """Provides the :class:`Arrow <arrow.parser.DateTimeParser>` class, a better way to parse datetime strings."""
 
 import re
-import sys
 from datetime import datetime, timedelta
 from datetime import tzinfo as dt_tzinfo
 from functools import lru_cache
@@ -11,12 +10,14 @@ from typing import (
     Dict,
     Iterable,
     List,
+    Literal,
     Match,
     Optional,
     Pattern,
     SupportsFloat,
     SupportsInt,
     Tuple,
+    TypedDict,
     Union,
     cast,
     overload,
@@ -27,11 +28,6 @@ from dateutil import tz
 from arrow import locales
 from arrow.constants import DEFAULT_LOCALE
 from arrow.util import next_weekday, normalize_timestamp
-
-if sys.version_info < (3, 8):  # pragma: no cover
-    from typing_extensions import Literal, TypedDict
-else:
-    from typing import Literal, TypedDict  # pragma: no cover
 
 
 class ParserError(ValueError):


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [x] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [x] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

Removed `typing_extensions` imports which were used for python<3.8, but this package requires python>=3.8.