### PR TITLE
Doc: Make it easier to find the supported tokens for `arrow.format` in the docs

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -1088,7 +1088,8 @@ class Arrow:
         self, fmt: str = "YYYY-MM-DD HH:mm:ssZZ", locale: str = DEFAULT_LOCALE
     ) -> str:
         """Returns a string representation of the :class:`Arrow <arrow.arrow.Arrow>` object,
-        formatted according to the provided format string.
+        formatted according to the provided format string. For a list of formatting values,
+        see :ref:`supported-tokens`
 
         :param fmt: the format string.
         :param locale: the locale to format.

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -156,6 +156,8 @@ Move between the earlier and later moments of an ambiguous time:
 Format
 ~~~~~~
 
+For a list of formatting values, see :ref:`supported-tokens`
+
 .. code-block:: python
 
     >>> arrow.utcnow().format('YYYY-MM-DD HH:mm:ss ZZ')
@@ -364,6 +366,8 @@ Then get and use a factory for it:
 
     >>> custom.days_till_xmas()
     >>> 211
+
+.. _supported-tokens:
 
 Supported Tokens
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [ ] 🧪  Added **tests** for changed code.
- [ ] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [ ] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [ ] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

Closes #1167.  Added 2 links to the [supported tokens ](https://arrow.readthedocs.io/en/latest/guide.html#supported-tokens) section. One in the `format` api reference and one in the user guide for `format`.


![image](https://github.com/arrow-py/arrow/assets/9763064/78ccd4c3-e65b-462c-88a0-eba409921510)

![image](https://github.com/arrow-py/arrow/assets/9763064/553e19e3-c749-4c7c-bc59-36c9c3f232e6)

<!--
Replace this commented text block with a description of your code changes.

If your PR has an associated issue, insert the issue number (e.g. #703) or directly link to the GitHub issue (e.g. https://github.com/arrow-py/arrow/issues/703).

Pro-tip: writing "Closes: #703" in the PR body will automatically close issue #703 when the PR is merged.
-->
