### PR TITLE
Modifying Spelling `제작년`, Remove poorly used expressions

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -1140,7 +1140,6 @@ class KoreanLocale(Locale):
     }
 
     special_dayframes = {
-        -3: "그끄제",
         -2: "그제",
         -1: "어제",
         1: "내일",
@@ -1149,7 +1148,7 @@ class KoreanLocale(Locale):
         4: "그글피",
     }
 
-    special_yearframes = {-2: "제작년", -1: "작년", 1: "내년", 2: "내후년"}
+    special_yearframes = {-2: "재작년", -1: "작년", 1: "내년", 2: "내후년"}
 
     month_names = [
         "",

--- a/tests/test_locales.py
+++ b/tests/test_locales.py
@@ -2390,14 +2390,14 @@ class TestKoreanLocale:
         assert self.locale._format_relative("2시간", "hours", -2) == "2시간 전"
         assert self.locale._format_relative("하루", "day", -1) == "어제"
         assert self.locale._format_relative("2일", "days", -2) == "그제"
-        assert self.locale._format_relative("3일", "days", -3) == "그끄제"
+        assert self.locale._format_relative("3일", "days", -3) == "3일 전"
         assert self.locale._format_relative("4일", "days", -4) == "4일 전"
         assert self.locale._format_relative("1주", "week", -1) == "1주 전"
         assert self.locale._format_relative("2주", "weeks", -2) == "2주 전"
         assert self.locale._format_relative("한달", "month", -1) == "한달 전"
         assert self.locale._format_relative("2개월", "months", -2) == "2개월 전"
         assert self.locale._format_relative("1년", "year", -1) == "작년"
-        assert self.locale._format_relative("2년", "years", -2) == "제작년"
+        assert self.locale._format_relative("2년", "years", -2) == "재작년"
         assert self.locale._format_relative("3년", "years", -3) == "3년 전"
 
     def test_ordinal_number(self):


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [x] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [x] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes
- The expression '그끄제' is rarely used in Korean expressions. Instead, the expression '3일전' is more natural.
- I've corrected the spelling. '재작년', not '제작년', is the right expression.

<!--
Replace this commented text block with a description of your code changes.

If your PR has an associated issue, insert the issue number (e.g. #703) or directly link to the GitHub issue (e.g. https://github.com/arrow-py/arrow/issues/703).

Pro-tip: writing "Closes: #703" in the PR body will automatically close issue #703 when the PR is merged.
-->
