### PR TITLE
#1178: changes to address datetime.utcnow deprecation warning

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -11,7 +11,7 @@ import sys
 from datetime import date
 from datetime import datetime as dt_datetime
 from datetime import time as dt_time
-from datetime import timedelta
+from datetime import timedelta, timezone
 from datetime import tzinfo as dt_tzinfo
 from math import trunc
 from time import struct_time
@@ -1144,7 +1144,7 @@ class Arrow:
         locale = locales.get_locale(locale)
 
         if other is None:
-            utc = dt_datetime.utcnow().replace(tzinfo=dateutil_tz.tzutc())
+            utc = dt_datetime.now(timezone.utc).replace(tzinfo=dateutil_tz.tzutc())
             dt = utc.astimezone(self._datetime.tzinfo)
 
         elif isinstance(other, Arrow):

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -1,7 +1,7 @@
 import pickle
 import sys
 import time
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import List
 
 import dateutil
@@ -91,7 +91,7 @@ class TestTestArrowFactory:
         result = arrow.Arrow.utcnow()
 
         assert_datetime_equality(
-            result._datetime, datetime.utcnow().replace(tzinfo=tz.tzutc())
+            result._datetime, datetime.now(timezone.utc).replace(tzinfo=tz.tzutc())
         )
 
         assert result.fold == 0
@@ -124,7 +124,7 @@ class TestTestArrowFactory:
 
         result = arrow.Arrow.utcfromtimestamp(timestamp)
         assert_datetime_equality(
-            result._datetime, datetime.utcnow().replace(tzinfo=tz.tzutc())
+            result._datetime, datetime.now(timezone.utc).replace(tzinfo=tz.tzutc())
         )
 
         with pytest.raises(ValueError):
@@ -1055,7 +1055,11 @@ class TestArrowRange:
 
     def test_unsupported(self):
         with pytest.raises(ValueError):
-            next(arrow.Arrow.range("abc", datetime.utcnow(), datetime.utcnow()))
+            next(
+                arrow.Arrow.range(
+                    "abc", datetime.now(timezone.utc), datetime.now(timezone.utc)
+                )
+            )
 
     def test_range_over_months_ending_on_different_days(self):
         # regression test for issue #842
@@ -2889,7 +2893,7 @@ class TestArrowUtil:
         get_datetime = arrow.Arrow._get_datetime
 
         arw = arrow.Arrow.utcnow()
-        dt = datetime.utcnow()
+        dt = datetime.now(timezone.utc)
         timestamp = time.time()
 
         assert get_datetime(arw) == arw.datetime

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,5 +1,5 @@
 import time
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from decimal import Decimal
 
 import pytest
@@ -15,7 +15,7 @@ from .utils import assert_datetime_equality
 class TestGet:
     def test_no_args(self):
         assert_datetime_equality(
-            self.factory.get(), datetime.utcnow().replace(tzinfo=tz.tzutc())
+            self.factory.get(), datetime.now(timezone.utc).replace(tzinfo=tz.tzutc())
         )
 
     def test_timestamp_one_arg_no_arg(self):
@@ -31,7 +31,7 @@ class TestGet:
     def test_struct_time(self):
         assert_datetime_equality(
             self.factory.get(time.gmtime()),
-            datetime.utcnow().replace(tzinfo=tz.tzutc()),
+            datetime.now(timezone.utc).replace(tzinfo=tz.tzutc()),
         )
 
     def test_one_arg_timestamp(self):
@@ -91,7 +91,7 @@ class TestGet:
         assert arw == result
 
     def test_one_arg_datetime(self):
-        dt = datetime.utcnow().replace(tzinfo=tz.tzutc())
+        dt = datetime.now(timezone.utc).replace(tzinfo=tz.tzutc())
 
         assert self.factory.get(dt) == dt
 
@@ -103,7 +103,7 @@ class TestGet:
 
     def test_one_arg_tzinfo(self):
         self.expected = (
-            datetime.utcnow()
+            datetime.now(timezone.utc)
             .replace(tzinfo=tz.tzutc())
             .astimezone(tz.gettz("US/Pacific"))
         )
@@ -123,7 +123,7 @@ class TestGet:
 
     def test_kwarg_tzinfo(self):
         self.expected = (
-            datetime.utcnow()
+            datetime.now(timezone.utc)
             .replace(tzinfo=tz.tzutc())
             .astimezone(tz.gettz("US/Pacific"))
         )
@@ -134,7 +134,7 @@ class TestGet:
 
     def test_kwarg_tzinfo_string(self):
         self.expected = (
-            datetime.utcnow()
+            datetime.now(timezone.utc)
             .replace(tzinfo=tz.tzutc())
             .astimezone(tz.gettz("US/Pacific"))
         )
@@ -199,7 +199,7 @@ class TestGet:
         assert_datetime_equality(result, expected)
 
     def test_one_arg_iso_str(self):
-        dt = datetime.utcnow()
+        dt = datetime.now(timezone.utc)
 
         assert_datetime_equality(
             self.factory.get(dt.isoformat()), dt.replace(tzinfo=tz.tzutc())
@@ -273,7 +273,7 @@ class TestGet:
 
     def test_two_args_datetime_other(self):
         with pytest.raises(TypeError):
-            self.factory.get(datetime.utcnow(), object())
+            self.factory.get(datetime.now(timezone.utc), object())
 
     def test_two_args_date_other(self):
         with pytest.raises(TypeError):
@@ -374,7 +374,7 @@ class TestUtcNow:
     def test_utcnow(self):
         assert_datetime_equality(
             self.factory.utcnow()._datetime,
-            datetime.utcnow().replace(tzinfo=tz.tzutc()),
+            datetime.now(timezone.utc).replace(tzinfo=tz.tzutc()),
         )
 
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 import pytz
@@ -113,7 +113,7 @@ class TestFormatterFormatToken:
         assert self.formatter._format_token(dt, "x") == expected
 
     def test_timezone(self):
-        dt = datetime.utcnow().replace(tzinfo=dateutil_tz.gettz("US/Pacific"))
+        dt = datetime.now(timezone.utc).replace(tzinfo=dateutil_tz.gettz("US/Pacific"))
 
         result = self.formatter._format_token(dt, "ZZ")
         assert result == "-07:00" or result == "-08:00"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,7 +1,7 @@
 import calendar
 import os
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 from dateutil import tz
@@ -1149,7 +1149,7 @@ class TestDateTimeParserISO:
         )
 
     def test_isoformat(self):
-        dt = datetime.utcnow()
+        dt = datetime.now(timezone.utc)
 
         assert self.parser.parse_iso(dt.isoformat()) == dt
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,5 @@
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -87,7 +87,7 @@ class TestUtil:
         except (ValueError, TypeError) as exp:
             pytest.fail(f"Exception raised when shouldn't have ({type(exp)}).")
 
-        ordinal = datetime.utcnow().toordinal()
+        ordinal = datetime.now(timezone.utc).toordinal()
         ordinal_str = str(ordinal)
         ordinal_float = float(ordinal) + 0.5
 


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [x] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes
Python has raised deprecation warning for the use of `datetime.datetime.utcnow()`. The suggestion is to use  `datetime.datetime.now(datetime.UTC)` or similar. 

This PR addresses just by swapping out all datetime utcnow() calls.
I don't think there's anything in documentation to be updated. 

With the example raised in #1178 with `humanize()`: 

Python 3.12: 
```
Python 3.12.4 (main, Jun  6 2024, 18:26:44) [Clang 15.0.0 (clang-1500.3.9.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import arrow
>>> time = arrow.utcnow()
>>> time.humanize()
'just now'
>>> 
```
No more deprecation warning. 

This also works with other python versions, like python 3.11: 
```
Python 3.11.9 (main, Apr  2 2024, 08:25:04) [Clang 15.0.0 (clang-1500.3.9.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import arrow
>>> time = arrow.utcnow()
>>> time.humanize()
'just now'
>>> time
<Arrow [2024-08-07T02:20:54.376543+00:00]>
>>> 
```

---------------------------------------------------------------


One thing to note as I setup `virtualenv` for this: 
Despite being listed in requirements.txt, `python-dateutil` wasn't installed with `make build`. I had to manually install it. 
```
-> % pip install python-dateutil
Looking in indexes: https://tdo:****@artifactory.sie.sony.com/artifactory/api/pypi/cgei-pypi-release-virtual/simple
Collecting python-dateutil
  Using cached https://artifactory.sie.sony.com/artifactory/api/pypi/cgei-pypi-release-virtual/packages/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl (229 kB)
Collecting six>=1.5 (from python-dateutil)
  Using cached https://artifactory.sie.sony.com/artifactory/api/pypi/cgei-pypi-release-virtual/packages/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl (11 kB)
Installing collected packages: six, python-dateutil
Successfully installed python-dateutil-2.9.0.post0 six-1.16.0
```
But that's a different thing to this PR. 

Closes https://github.com/arrow-py/arrow/issues/1178
