### PR TITLE
Move dateutil types to test requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
 ]
 dependencies = [
     "python-dateutil>=2.7.0",
-    "types-python-dateutil>=2.8.10",
 ]
 requires-python = ">=3.8"
 description = "Better dates & times for Python"

--- a/requirements/requirements-tests.txt
+++ b/requirements/requirements-tests.txt
@@ -6,3 +6,4 @@ pytest-cov
 pytest-mock
 pytz==2021.1
 simplejson==3.*
+types-python-dateutil>=2.8.10

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,2 +1,1 @@
 python-dateutil>=2.7.0
-types-python-dateutil>=2.8.10


### PR DESCRIPTION
## Pull Request Checklist

- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [x] ⏩  Code is **up-to-date** with the `master` branch.

## Description of Changes

types-python-dateutils is only needed when running mypy static type checking; move from runtime to test requirements.