### PR TITLE
Improve "ago" translation to Greek

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -654,7 +654,7 @@ class FrenchCanadianLocale(FrenchBaseLocale, Locale):
 class GreekLocale(Locale):
     names = ["el", "el-gr"]
 
-    past = "{0} πριν"
+    past = "πριν από {0}"
     future = "σε {0}"
     and_word = "και"
 
@@ -697,7 +697,7 @@ class GreekLocale(Locale):
         "Φεβ",
         "Μαρ",
         "Απρ",
-        "Μαϊ",
+        "Μαΐ",
         "Ιον",
         "Ιολ",
         "Αυγ",

--- a/tests/test_locales.py
+++ b/tests/test_locales.py
@@ -3178,3 +3178,14 @@ class TestUzbekLocale:
         assert self.locale._format_timeframe("months", 11) == "11 oy"
         assert self.locale._format_timeframe("year", 1) == "bir yil"
         assert self.locale._format_timeframe("years", 12) == "12 yil"
+
+
+@pytest.mark.usefixtures("lang_locale")
+class TestGreekLocale:
+    def test_format_relative_future(self):
+        result = self.locale._format_relative("μία ώρα", "ώρα", -1)
+
+        assert result == "πριν από μία ώρα"  # an hour ago
+
+    def test_month_abbreviation(self):
+        assert self.locale.month_abbreviations[5] == "Μαΐ"


### PR DESCRIPTION
## Pull Request Checklist

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [x] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

## Description of Changes

Hello and thanks for this library! While trying to migrate from `humanize` package to `arrow`, I executed

```
>>> arrow.get('2013-05-11T21:23:58.970460+07:00').humanize()
'11 years ago'
>>> arrow.get('2013-05-11T21:23:58.970460+07:00').humanize(locale='el')
'11 χρόνια πριν'
```

The later is printed by `humanize` as
```
'πριν από 11 χρόνια'
```
which is more natural/correct in Greek.

https://github.com/python-humanize/humanize/blob/4da8299fdcf9ad0c56be082b42ee7bee14ee4c4e/src/humanize/locale/el_GR/LC_MESSAGES/humanize.po#L344

Other than that, I fixed Greek abbreviated May accent, so as to be aligned with the full name 15 lines above.