### PR TITLE
Update shift() for issue #1145

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -491,7 +491,7 @@ class Arrow:
             yield current
 
             values = [getattr(current, f) for f in cls._ATTRS]
-            current = cls(*values).shift(
+            current = cls(*values, tzinfo=tzinfo).shift(  # type: ignore[misc]
                 check_imaginary=True, **{frame_relative: relative_steps}
             )
 

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -491,8 +491,8 @@ class Arrow:
             yield current
 
             values = [getattr(current, f) for f in cls._ATTRS]
-            current = cls(*values, tzinfo=tzinfo).shift(  # type: ignore[misc]
-                **{frame_relative: relative_steps}
+            current = cls(*values).shift(
+                check_imaginary=True, **{frame_relative: relative_steps}
             )
 
             if frame in ["month", "quarter", "year"] and current.day < original_day:
@@ -583,7 +583,9 @@ class Arrow:
             elif frame_absolute == "quarter":
                 floor = floor.shift(months=-((self.month - 1) % 3))
 
-        ceil = floor.shift(**{frame_relative: count * relative_steps})
+        ceil = floor.shift(
+            check_imaginary=True, **{frame_relative: count * relative_steps}
+        )
 
         if bounds[0] == "(":
             floor = floor.shift(microseconds=+1)
@@ -981,7 +983,7 @@ class Arrow:
 
         return self.fromdatetime(current)
 
-    def shift(self, check_imaginary=True, **kwargs: Any) -> "Arrow":
+    def shift(self, check_imaginary: bool = True, **kwargs: Any) -> "Arrow":
         """Returns a new :class:`Arrow <arrow.arrow.Arrow>` object with attributes updated
         according to inputs.
 
@@ -1447,7 +1449,7 @@ class Arrow:
 
         time_changes = {k: sign_val * v for k, v in time_object_info.items()}
 
-        return current_time.shift(**time_changes)
+        return current_time.shift(check_imaginary=True, **time_changes)
 
     # query functions
 

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -981,9 +981,14 @@ class Arrow:
 
         return self.fromdatetime(current)
 
-    def shift(self, **kwargs: Any) -> "Arrow":
+    def shift(self, check_imaginary=True, **kwargs: Any) -> "Arrow":
         """Returns a new :class:`Arrow <arrow.arrow.Arrow>` object with attributes updated
         according to inputs.
+
+        Parameters:
+        check_imaginary (bool): If True (default), will check for and resolve
+        imaginary times (like during DST transitions). If False, skips this check.
+
 
         Use pluralized property names to relatively shift their current value:
 
@@ -1031,7 +1036,8 @@ class Arrow:
 
         current = self._datetime + relativedelta(**relative_kwargs)
 
-        if not dateutil_tz.datetime_exists(current):
+        # If check_imaginary is True, perform the check for imaginary times (DST transitions)
+        if check_imaginary and not dateutil_tz.datetime_exists(current):
             current = dateutil_tz.resolve_imaginary(current)
 
         return self.fromdatetime(current)

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -847,6 +847,16 @@ class TestArrowShift:
             2011, 12, 31, 23, tzinfo="Pacific/Apia"
         )
 
+    def test_shift_with_imaginary_check(self):
+        dt = arrow.Arrow(2024, 3, 10, 2, 30, tzinfo=tz.gettz("US/Eastern"))
+        shifted = dt.shift(hours=1)
+        assert shifted.datetime.hour == 3
+
+    def test_shift_without_imaginary_check(self):
+        dt = arrow.Arrow(2024, 3, 10, 2, 30, tzinfo=tz.gettz("US/Eastern"))
+        shifted = dt.shift(hours=1, check_imaginary=False)
+        assert shifted.datetime.hour == 3
+
     @pytest.mark.skipif(
         dateutil.__version__ < "2.7.1", reason="old tz database (2018d needed)"
     )


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [x] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [x] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

Added check_imaginary parameter to the function referring to the issue #1145 
- New Parameter: Added a check_imaginary parameter (defaulting to True), which allows the user to decide whether or not to perform DST/imaginary time checks.
- Skip DST Check: The DST check logic:
block is only executed if check_imaginary is True. If set to False, this check is skipped for improved performance when DST changes are not a concern.

Benefits:
- Backward Compatibility: By default, the method still performs the DST/imaginary time checks, so existing code won't break.
- Performance Boost: Users who know that their datetime range does not involve DST transitions can set check_imaginary=False to skip the checks and improve performance.
