### PR TITLE
Add FORMAT_RFC3339_STRICT.

### DIFF
--- a/arrow/__init__.py
+++ b/arrow/__init__.py
@@ -11,6 +11,7 @@ from .formatter import (
     FORMAT_RFC1123,
     FORMAT_RFC2822,
     FORMAT_RFC3339,
+    FORMAT_RFC3339_STRICT,
     FORMAT_RSS,
     FORMAT_W3C,
 )
@@ -33,6 +34,7 @@ __all__ = [
     "FORMAT_RFC1123",
     "FORMAT_RFC2822",
     "FORMAT_RFC3339",
+    "FORMAT_RFC3339_STRICT",
     "FORMAT_RSS",
     "FORMAT_W3C",
     "ParserError",

--- a/arrow/formatter.py
+++ b/arrow/formatter.py
@@ -17,6 +17,7 @@ FORMAT_RFC1036: Final[str] = "ddd, DD MMM YY HH:mm:ss Z"
 FORMAT_RFC1123: Final[str] = "ddd, DD MMM YYYY HH:mm:ss Z"
 FORMAT_RFC2822: Final[str] = "ddd, DD MMM YYYY HH:mm:ss Z"
 FORMAT_RFC3339: Final[str] = "YYYY-MM-DD HH:mm:ssZZ"
+FORMAT_RFC3339_STRICT: Final[str] = "YYYY-MM-DDTHH:mm:ssZZ"
 FORMAT_RSS: Final[str] = "ddd, DD MMM YYYY HH:mm:ss Z"
 FORMAT_W3C: Final[str] = "YYYY-MM-DD HH:mm:ssZZ"
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -13,6 +13,7 @@ from arrow import (
     FORMAT_RFC1123,
     FORMAT_RFC2822,
     FORMAT_RFC3339,
+    FORMAT_RFC3339_STRICT,
     FORMAT_RSS,
     FORMAT_W3C,
 )
@@ -252,6 +253,12 @@ class TestFormatterBuiltinFormats:
         assert (
             self.formatter.format(self.datetime, FORMAT_RFC3339)
             == "1975-12-25 14:15:16-05:00"
+        )
+
+    def test_rfc3339_strict(self):
+        assert (
+            self.formatter.format(self.datetime, FORMAT_RFC3339_STRICT)
+            == "1975-12-25T14:15:16-05:00"
         )
 
     def test_rss(self):


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [x] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

Adds a FORMAT variable for a more strict RFC3339 where the RFC called for a space for readability and is used by FORMAT_RFC3339, FORMAT_RFC3339_STRICT uses the T separator to adhere with ISO8601 spec.

[RFC Link](https://www.rfc-editor.org/rfc/rfc3339#section-5.6)
```
      NOTE: ISO 8601 defines date and time separated by "T".
      Applications using this syntax may choose, for the sake of
      readability, to specify a full-date and full-time separated by
      (say) a space character.
```

Closes #1138