### PR TITLE
Fix date omission in span_range() when exact is True

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -699,7 +699,17 @@ class Arrow:
                 yield r.span(frame, bounds=bounds, exact=exact)
 
         for r in _range:
+            day_is_clipped = False
             floor, ceil = r.span(frame, bounds=bounds, exact=exact)
+            next = ceil.shift(microseconds=+1)
+            if frame == "month" and next.day < start.day:
+                day_is_clipped = True
+            if day_is_clipped and not next._is_last_day_of_month(next):
+                days_to_shift = (
+                    min(start.day, calendar.monthrange(next.year, next.month)[1])
+                    - next.day
+                )
+                ceil = ceil.shift(days=days_to_shift)
             if ceil > end:
                 ceil = end
                 if bounds[1] == ")":

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -701,6 +701,8 @@ class Arrow:
         for r in _range:
             day_is_clipped = False
             floor, ceil = r.span(frame, bounds=bounds, exact=exact)
+
+            # check that no dates are lost (#1185)
             next = ceil.shift(microseconds=+1)
             if frame == "month" and next.day < start.day:
                 day_is_clipped = True
@@ -710,6 +712,7 @@ class Arrow:
                     - next.day
                 )
                 ceil = ceil.shift(days=days_to_shift)
+
             if ceil > end:
                 ceil = end
                 if bounds[1] == ")":

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -1185,7 +1185,7 @@ class TestArrowSpanRange:
             (arrow.Arrow(2013, 4, 1), arrow.Arrow(2013, 4, 30, 23, 59, 59, 999999)),
         ]
 
-    def test_month_end(self):
+    def test_month_exact(self):
         result = list(
             arrow.Arrow.span_range(
                 "month", datetime(2013, 1, 31), datetime(2014, 1, 31), exact=True
@@ -1205,6 +1205,20 @@ class TestArrowSpanRange:
             (arrow.Arrow(2013, 10, 31), arrow.Arrow(2013, 11, 29, 23, 59, 59, 999999)),
             (arrow.Arrow(2013, 11, 30), arrow.Arrow(2013, 12, 30, 23, 59, 59, 999999)),
             (arrow.Arrow(2013, 12, 31), arrow.Arrow(2014, 1, 30, 23, 59, 59, 999999)),
+        ]
+
+    def test_month_exact_leap(self):
+        result = list(
+            arrow.Arrow.span_range(
+                "month", datetime(2012, 1, 31), datetime(2012, 5, 31), exact=True
+            )
+        )
+
+        assert result == [
+            (arrow.Arrow(2012, 1, 31), arrow.Arrow(2012, 2, 28, 23, 59, 59, 999999)),
+            (arrow.Arrow(2012, 2, 29), arrow.Arrow(2012, 3, 30, 23, 59, 59, 999999)),
+            (arrow.Arrow(2012, 3, 31), arrow.Arrow(2012, 4, 29, 23, 59, 59, 999999)),
+            (arrow.Arrow(2012, 4, 30), arrow.Arrow(2012, 5, 30, 23, 59, 59, 999999)),
         ]
 
     def test_week(self):

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -1185,6 +1185,28 @@ class TestArrowSpanRange:
             (arrow.Arrow(2013, 4, 1), arrow.Arrow(2013, 4, 30, 23, 59, 59, 999999)),
         ]
 
+    def test_month_end(self):
+        result = list(
+            arrow.Arrow.span_range(
+                "month", datetime(2013, 1, 31), datetime(2014, 1, 31), exact=True
+            )
+        )
+
+        assert result == [
+            (arrow.Arrow(2013, 1, 31), arrow.Arrow(2013, 2, 27, 23, 59, 59, 999999)),
+            (arrow.Arrow(2013, 2, 28), arrow.Arrow(2013, 3, 30, 23, 59, 59, 999999)),
+            (arrow.Arrow(2013, 3, 31), arrow.Arrow(2013, 4, 29, 23, 59, 59, 999999)),
+            (arrow.Arrow(2013, 4, 30), arrow.Arrow(2013, 5, 30, 23, 59, 59, 999999)),
+            (arrow.Arrow(2013, 5, 31), arrow.Arrow(2013, 6, 29, 23, 59, 59, 999999)),
+            (arrow.Arrow(2013, 6, 30), arrow.Arrow(2013, 7, 30, 23, 59, 59, 999999)),
+            (arrow.Arrow(2013, 7, 31), arrow.Arrow(2013, 8, 30, 23, 59, 59, 999999)),
+            (arrow.Arrow(2013, 8, 31), arrow.Arrow(2013, 9, 29, 23, 59, 59, 999999)),
+            (arrow.Arrow(2013, 9, 30), arrow.Arrow(2013, 10, 30, 23, 59, 59, 999999)),
+            (arrow.Arrow(2013, 10, 31), arrow.Arrow(2013, 11, 29, 23, 59, 59, 999999)),
+            (arrow.Arrow(2013, 11, 30), arrow.Arrow(2013, 12, 30, 23, 59, 59, 999999)),
+            (arrow.Arrow(2013, 12, 31), arrow.Arrow(2014, 1, 30, 23, 59, 59, 999999)),
+        ]
+
     def test_week(self):
         result = list(
             arrow.Arrow.span_range("week", datetime(2013, 2, 2), datetime(2013, 2, 28))


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [x] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [x] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

Fixed an edge case that occurred in span_range() that caused the omission of dates when frame = 'month', exact = True, and start.day > 28. 

span_range() now exhibits similar behavior to range() in this case where the returned Arrow object from span() is checked against the start date and updated accordingly.

Closes: #1185 
