### PR TITLE
fix(parser): raise ParserMatchError for malformed format strings (#1191)

### DIFF
--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -422,12 +422,21 @@ class DateTimeParser:
         parts: _Parts = {}
         for token in fmt_tokens:
             value: Union[Tuple[str, str, str], str]
-            if token == "Do":
-                value = match.group("value")
-            elif token == "W":
-                value = (match.group("year"), match.group("week"), match.group("day"))
-            else:
-                value = match.group(token)
+            try:
+                if token == "Do":
+                    value = match.group("value")
+                elif token == "W":
+                    value = (
+                        match.group("year"),
+                        match.group("week"),
+                        match.group("day"),
+                    )
+                else:
+                    value = match.group(token)
+            except IndexError:
+                raise ParserMatchError(
+                    f"Failed to match {fmt!r} when parsing {datetime_string!r}."
+                )
 
             if value is None:
                 raise ParserMatchError(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -529,6 +529,14 @@ class TestDateTimeParserParse:
 
         assert self.parser.parse("      2016      ", "YYYY") == datetime(2016, 1, 1)
 
+    def test_parse_Do_indexerror_becomes_parser_match_error(self):
+        """Regression for #1191: On locales whose ordinal_day_re does not expose
+        a named 'value' capture group (e.g. GermanLocale), match.group('value')
+        previously raised a bare IndexError. It must raise ParserMatchError."""
+        de_parser = DateTimeParser(locale="de")
+        with pytest.raises(ParserMatchError):
+            de_parser.parse("1", "Do")
+
         assert self.parser.parse(
             "      2016-05-16 04:05:06.789120      ", "YYYY-MM-DD hh:mm:ss.S"
         ) == datetime(2016, 5, 16, 4, 5, 6, 789120)


### PR DESCRIPTION
## Summary

Fixes #1191.

`DateTimeParser.parse()` raises a raw `IndexError` instead of `ParserMatchError` when given a malformed format string.

## Root Cause

Inside `parse()`, after the regex is successfully matched, the code iterates over `fmt_tokens` and calls `match.group(token)` for each one:

```python
for token in fmt_tokens:
    ...
    value = match.group(token)   # raises IndexError for malformed fmt
```

When the format string is malformed, the regex may match but not define a named capture group for every expected token. `match.group(token)` then raises `IndexError: no such group`, which propagates unhandled.

## Fix

Wrap the `match.group()` calls in `try/except IndexError` and re-raise as `ParserMatchError`, consistent with how the no-match case is handled just above the loop.

```diff
 for token in fmt_tokens:
+    try:
         if token == "Do":
             value = match.group("value")
         elif token == "W":
             value = (match.group("year"), match.group("week"), match.group("day"))
         else:
             value = match.group(token)
+    except IndexError:
+        raise ParserMatchError(
+            f"Failed to match {fmt!r} when parsing {datetime_string!r}."
+        )
```

Callers that already catch `ParserMatchError` will now also handle the malformed-format-string case without any changes on their side.
