### PR TITLE
Support decimal values in dehumanize

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -17,6 +17,7 @@ from time import struct_time
 from typing import (
     Any,
     ClassVar,
+    Dict,
     Final,
     Generator,
     Iterable,
@@ -1384,7 +1385,8 @@ class Arrow:
         current_time = self.fromdatetime(self._datetime)
 
         # Create an object containing the relative time info
-        time_object_info = dict.fromkeys(
+        # float as well as int: a value may carry a decimal fraction
+        time_object_info: Dict[str, Union[int, float]] = dict.fromkeys(
             ["seconds", "minutes", "hours", "days", "weeks", "months", "years"], 0
         )
 
@@ -1431,6 +1433,7 @@ class Arrow:
 
                 # If no number matches
                 # Need for absolute value as some locales have signs included in their objects
+                change_value: Union[int, float]
                 if not num_match:
                     change_value = (
                         1 if not time_delta.isnumeric() else abs(int(time_delta))

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -74,6 +74,9 @@ _GRANULARITY = Literal[
     "year",
 ]
 
+# An unsigned integer or decimal, as accepted by dehumanize()
+_NUMBER_PATTERN = r"\d+(?:[.,]\d+)?"
+
 
 class Arrow:
     """An :class:`Arrow <arrow.arrow.Arrow>` object.
@@ -1391,8 +1394,13 @@ class Arrow:
             False,
         )
 
-        # Create a regex pattern object for numbers
-        num_pattern = re.compile(r"\d+")
+        # Create a regex pattern object for numbers.
+        # A value may carry a decimal fraction ("3.5 hours"). Both separators
+        # are accepted because the input is written by hand rather than
+        # produced by humanize(), and the locale objects carry no separator
+        # information. A separator is only read as a decimal point when digits
+        # follow it, so digit grouping ("1,500 hours") is not supported.
+        num_pattern = re.compile(_NUMBER_PATTERN)
 
         # Search input string for each time unit within locale
         for unit, unit_object in locale_obj.timeframes.items():
@@ -1406,9 +1414,9 @@ class Arrow:
             # Needs to cycle all through strings as some locales have strings that
             # could overlap in a regex match, since input validation isn't being performed.
             for time_delta, time_string in strings_to_search.items():
-                # Replace {0} with regex \d representing digits
+                # Replace {0} with the regex matching a numeric value
                 search_string = str(time_string)
-                search_string = search_string.format(r"\d+")
+                search_string = search_string.format(_NUMBER_PATTERN)
 
                 # Create search pattern and find within string
                 pattern = re.compile(rf"(^|\b|\d){search_string}")
@@ -1428,7 +1436,12 @@ class Arrow:
                         1 if not time_delta.isnumeric() else abs(int(time_delta))
                     )
                 else:
-                    change_value = int(num_match.group())
+                    matched_number = num_match.group().replace(",", ".")
+                    change_value = (
+                        float(matched_number)
+                        if "." in matched_number
+                        else int(matched_number)
+                    )
 
                 # No time to update if now is the unit
                 if unit == "now":

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -2930,6 +2930,41 @@ class TestArrowDehumanize:
             with pytest.raises(ValueError):
                 arw.dehumanize(empty_future_string, locale=lang)
 
+    def test_fractional_value(self):
+        arw = arrow.Arrow(2025, 12, 10, 9, 0, 0)
+
+        assert arw.dehumanize("1.5 hours ago") == arrow.Arrow(2025, 12, 10, 7, 30, 0)
+        assert arw.dehumanize("in 0.5 hours") == arrow.Arrow(2025, 12, 10, 9, 30, 0)
+        assert arw.dehumanize("2.25 minutes ago") == arrow.Arrow(
+            2025, 12, 10, 8, 57, 45
+        )
+        assert arw.dehumanize("in 1.5 days") == arrow.Arrow(2025, 12, 11, 21, 0, 0)
+
+    def test_fractional_value_comma_separator(self):
+        arw = arrow.Arrow(2025, 12, 10, 9, 0, 0)
+
+        assert arw.dehumanize("1,5 hours ago") == arw.dehumanize("1.5 hours ago")
+
+    def test_fractional_value_with_multiple_units(self):
+        arw = arrow.Arrow(2025, 12, 10, 9, 0, 0)
+
+        assert arw.dehumanize("2 days 3.5 hours ago") == arrow.Arrow(
+            2025, 12, 8, 5, 30, 0
+        )
+        assert arw.dehumanize("in 2 days 3.5 hours") == arrow.Arrow(
+            2025, 12, 12, 12, 30, 0
+        )
+
+    def test_fractional_months_and_years_are_rejected(self):
+        arw = arrow.Arrow(2025, 12, 10, 9, 0, 0)
+
+        # relativedelta cannot represent these unambiguously
+        with pytest.raises(ValueError):
+            arw.dehumanize("1.5 months ago")
+
+        with pytest.raises(ValueError):
+            arw.dehumanize("in 1.5 years")
+
     def test_slavic_locales(self, slavic_locales: List[str]):
         # Relevant units for Slavic locale plural logic
         units = [


### PR DESCRIPTION
Fixes #1237.

## Problem

```python
>>> arrow.get("2025-12-10T09:00:00").dehumanize("2 days 3.5 hours ago")
<Arrow [2025-12-08T04:00:00+00:00]>   # 2 days 5 hours
```

The number pattern is `\d+`, so for `3.5 hours` the search lands on the digits *after* the separator and the `3` is dropped. Expected `<Arrow [2025-12-08T05:30:00+00:00]>`.

## Fix

The pattern becomes `\d+(?:[.,]\d+)?`, shared as `_NUMBER_PATTERN` between the two places that needed it (the per-timeframe search string and the number extraction). A matched value keeps parsing as `int` when it has no fraction, so nothing changes for the strings `humanize()` produces — only the new decimal case yields a `float`.

`relativedelta` accepts floats for seconds through weeks, so `shift()` needed no change.

## On the separator

Both `.` and `,` are accepted, as the issue suggests. The locale objects carry no decimal-separator information, and `dehumanize` input is written by hand rather than produced by `humanize()`, so there is nothing to key the choice off. The separator only counts when digits follow it, which is what keeps it from firing on a locale's own punctuation.

The trade-off is that digit grouping (`"1,500 hours"`) is read as `1.5`. That input is already wrong today — `\d+` matches just `1` — so this is not a regression, but it is not a case I tried to support; I noted it in a comment next to the pattern. Happy to restrict to `.` only if you would rather not accept the ambiguity.

## Fractional months and years

`relativedelta` rejects these outright (*"Non-integer years and months are ambiguous and not currently supported"*), which surfaces as a `ValueError` from `dehumanize`. That seemed better than silently truncating; there is a test pinning it.

## Tests

- `test_fractional_value` — hours, minutes and days, both directions.
- `test_fractional_value_comma_separator` — `1,5` matches `1.5`.
- `test_fractional_value_with_multiple_units` — the exact case from the issue, plus its future form.
- `test_fractional_months_and_years_are_rejected`.

Full suite passes (1903 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)