### PR TITLE
fix(types): use Union[Arrow, dt_datetime] for span_range and interval start/end params

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -643,8 +643,8 @@ class Arrow:
     def span_range(
         cls,
         frame: _T_FRAMES,
-        start: dt_datetime,
-        end: dt_datetime,
+        start: Union["Arrow", dt_datetime],
+        end: Union["Arrow", dt_datetime],
         tz: Optional[TZ_EXPR] = None,
         limit: Optional[int] = None,
         bounds: _BOUNDS = "[)",
@@ -702,8 +702,10 @@ class Arrow:
         """
 
         tzinfo = cls._get_tzinfo(start.tzinfo if tz is None else tz)
-        start = cls.fromdatetime(start, tzinfo).span(frame, exact=exact)[0]
-        end = cls.fromdatetime(end, tzinfo)
+        start = cls.fromdatetime(cls._get_datetime(start), tzinfo).span(
+            frame, exact=exact
+        )[0]
+        end = cls.fromdatetime(cls._get_datetime(end), tzinfo)
         _range = cls.range(frame, start, end, tz, limit)
         if not exact:
             for r in _range:
@@ -725,8 +727,8 @@ class Arrow:
     def interval(
         cls,
         frame: _T_FRAMES,
-        start: dt_datetime,
-        end: dt_datetime,
+        start: Union["Arrow", dt_datetime],
+        end: Union["Arrow", dt_datetime],
         interval: int = 1,
         tz: Optional[TZ_EXPR] = None,
         bounds: _BOUNDS = "[)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 test = [
-    "dateparser==1.*",
-    "pre-commit",
+    "dateparser==1.*; platform_python_implementation != 'PyPy' or sys_platform != 'win32'",
+    "pre-commit; platform_python_implementation != 'PyPy' or sys_platform != 'win32'",
     "pytest",
     "pytest-cov",
     "pytest-mock",

--- a/requirements/requirements-tests.txt
+++ b/requirements/requirements-tests.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
-dateparser==1.*
-pre-commit
+dateparser==1.*; platform_python_implementation != "PyPy" or sys_platform != "win32"
+pre-commit; platform_python_implementation != "PyPy" or sys_platform != "win32"
 pytest
 pytest-cov
 pytest-mock


### PR DESCRIPTION
Fixes #1210.

`Arrow.span_range()` and `Arrow.interval()` accept `start` and `end` bounds like
`Arrow.range()` does, but their annotations only allowed `datetime`.

This updates those annotations to accept `Arrow | datetime` and normalizes
`Arrow` bounds before passing them through `fromdatetime()`.

The test dependency markers also skip two optional test-only dependencies on
Windows PyPy. The affected `dateparser` regression test already uses
`pytest.importorskip("dateparser")`, and `pre-commit` is only needed by the
lint environment.

Tests:

```bash
tox -e lint
tox -e py314
```

---
Restored after an accidental fork deletion. Same commits as #1267.