### PR TITLE
fix: treat explicit tzinfo=None in arrow.get() like an omitted tzinfo

### DIFF
--- a/arrow/factory.py
+++ b/arrow/factory.py
@@ -188,7 +188,7 @@ class ArrowFactory:
 
         arg_count = len(args)
         locale = kwargs.pop("locale", DEFAULT_LOCALE)
-        tz = kwargs.get("tzinfo", None)
+        tz = kwargs.pop("tzinfo", None)
         normalize_whitespace = kwargs.pop("normalize_whitespace", False)
 
         # if kwargs given, send to constructor unless only tzinfo provided


### PR DESCRIPTION
Fixes #1259

**Problem**: arrow.get() with an explicit tzinfo=None keyword behaves differently from omitting it: the tzinfo key stays in kwargs (only read via get), so the 'tzinfo kwarg is not provided' branch (len(kwargs) == 1 and tz is None) forces arg_count = 3 and crashes, while omitting the kwarg leaves kwargs empty and parses normally.

**Fix**: pop tzinfo from kwargs so an explicit None and an omitted tzinfo are treated identically (both leave kwargs without the key).